### PR TITLE
[SMART-13] Add template component files and script [skip ci]

### DIFF
--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -1,0 +1,94 @@
+const [, , type, component] = process.argv;
+const fs = require("fs");
+
+const hasUpperCase = (string) => !(string.toLowerCase() === string);
+const capitalizeFirstLetter = (string) => `${string.charAt(0).toUpperCase()}${string.slice(1)}`;
+const transformToCamelcase = (string, separator) =>
+  string
+    .split(separator)
+    .map((str) => capitalizeFirstLetter(str))
+    .join("");
+
+const replaceIndex = (string, toReplace, at, repl) => {
+  var re = new RegExp(toReplace, "g");
+  console.log(toReplace);
+
+  const indexes = [...string.matchAll(re)].map((a) => a.index);
+  const wantedIndexes = at.map((index) => indexes[index]);
+
+  console.log(wantedIndexes);
+  return string.replace(re, function (match, i) {
+    if (wantedIndexes.includes(i)) {
+      return repl;
+    }
+
+    return match;
+  });
+};
+
+if (hasUpperCase(type) || hasUpperCase(component)) {
+  console.error(
+    `ERROR --> Type (${type}) or component (${component}) contains uppercase. Avoid using upperCase in naming (example: button-with-icon)`
+  );
+  process.exit(1);
+}
+
+const camelCaseComponentName = transformToCamelcase(component, "-");
+
+const COMPONENT_TEMPLATE_FOLDER = "./templates/component";
+const COMPONENT_FOLDER = `./src/components/${component}`;
+
+fs.mkdir(COMPONENT_FOLDER, { recursive: true }, (err) => {
+  if (err) throw err;
+});
+
+fs.readdir(COMPONENT_TEMPLATE_FOLDER, (err, filenames) => {
+  if (err) throw err;
+
+  filenames.map((filename) => {
+    fs.readFile(`${COMPONENT_TEMPLATE_FOLDER}/${filename}`, "utf8", (err, data) => {
+      if (err) throw err;
+
+      let fileData;
+
+      if (filename.includes("styles")) {
+        fileData = data;
+      } else if (filename.includes("stories")) {
+        fileData = replaceIndex(data, "component", [0], component);
+        fileData = replaceIndex(
+          fileData,
+          "Component",
+          [2, 3, 4, 6, 8, 9, 10, 11],
+          camelCaseComponentName
+        );
+        fileData = fileData.replace("storyType", capitalizeFirstLetter(type));
+      } else {
+        fileData = data
+          .replace(/component/g, component)
+          .replace(/Component/g, camelCaseComponentName);
+      }
+
+      const finalFilename = filename.replace("component", component);
+
+      fs.writeFile(
+        `${COMPONENT_FOLDER}/${finalFilename}`,
+        fileData,
+        { encoding: "utf8" },
+        (err) => {
+          if (err) throw err;
+        }
+      );
+    });
+  });
+});
+
+fs.readFile(`./src/components/index.ts`, "utf8", (err, data) => {
+  if (err) throw err;
+
+  fileData = data + "\n" + `export { default as ${camelCaseComponentName} } from "./${component}"`;
+  fileData = fileData.replace(/^\s*\n/gm, "");
+
+  fs.writeFile(`./src/components/index.ts`, fileData, { encoding: "utf8" }, (err) => {
+    if (err) throw err;
+  });
+});

--- a/templates/component/component.stories.tsx
+++ b/templates/component/component.stories.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Component from "./component";
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: "storyType/Component",
+  component: Component,
+} as ComponentMeta<typeof Component>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof Component> = (args) => <Component {...args} />;
+
+export const ComponentTemplate = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+ComponentTemplate.args = {};

--- a/templates/component/component.styles.ts
+++ b/templates/component/component.styles.ts
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const Container = styled.div``;

--- a/templates/component/component.test.js
+++ b/templates/component/component.test.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import Component from "./component";
+
+describe(`Component`, () => {
+  test("renders Component", () => {
+    render(<Component />);
+  });
+});

--- a/templates/component/component.tsx
+++ b/templates/component/component.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import * as S from "./component.styles";
+import { ComponentProps } from "./component.types";
+
+const Component: React.FC<ComponentProps> = () => {
+  return <S.Container>Container</S.Container>;
+};
+
+export default Component;

--- a/templates/component/component.types.ts
+++ b/templates/component/component.types.ts
@@ -1,0 +1,1 @@
+export type ComponentProps = {};

--- a/templates/component/index.ts
+++ b/templates/component/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./component";


### PR DESCRIPTION
## Related Jira ticket 🎫
[SMART-13](https://smartcookie.atlassian.net/browse/SMART-13)


## Implementation details 🕵️
Create a component template folder with component files:
- Component
- Styles
- Types
- Tests

Add script to generate a new component


## Additional Info ℹ️
To generate a new component run the command: `node  scripts/create-component [component-type] [component-name]`
- Component type and component name must be lower case
- The component name must be **Kebab-case**

