### PR TITLE
Fix fonts imports

### DIFF
--- a/src/global-styles/assets/fonts.d.ts
+++ b/src/global-styles/assets/fonts.d.ts
@@ -1,0 +1,3 @@
+declare module "*.woff";
+declare module "*.woff2";
+declare module "*.ttf";

--- a/src/global-styles/font-styles.tsx
+++ b/src/global-styles/font-styles.tsx
@@ -1,27 +1,27 @@
 import { createGlobalStyle } from "styled-components";
-const fontMontserratBoldTtf = require("./assets/Montserrat-Bold.ttf");
-const fontMontserratBoldWoff = require("./assets/Montserrat-Bold.woff");
-const fontMontserratBoldWoff2 = require("./assets/Montserrat-Bold.woff2");
+import fontMontserratBoldTtf from "./assets/Montserrat-Bold.ttf";
+import fontMontserratBoldWoff from "./assets/Montserrat-Bold.woff";
+import fontMontserratBoldWoff2 from "./assets/Montserrat-Bold.woff2";
 
-const fontMontserratBoldItalicTtf = require("./assets/Montserrat-BoldItalic.ttf");
-const fontMontserratBoldItalicWoff = require("./assets/Montserrat-BoldItalic.woff");
-const fontMontserratBoldItalicWoff2 = require("./assets/Montserrat-BoldItalic.woff2");
+import fontMontserratBoldItalicTtf from "./assets/Montserrat-BoldItalic.ttf";
+import fontMontserratBoldItalicWoff from "./assets/Montserrat-BoldItalic.woff";
+import fontMontserratBoldItalicWoff2 from "./assets/Montserrat-BoldItalic.woff2";
 
-const fontMontserratRegularTtf = require("./assets/Montserrat-Regular.ttf");
-const fontMontserratRegularWoff = require("./assets/Montserrat-Regular.woff");
-const fontMontserratRegularWoff2 = require("./assets/Montserrat-Regular.woff2");
+import fontMontserratRegularTtf from "./assets/Montserrat-Regular.ttf";
+import fontMontserratRegularWoff from "./assets/Montserrat-Regular.woff";
+import fontMontserratRegularWoff2 from "./assets/Montserrat-Regular.woff2";
 
-const fontMontserratItalicTtf = require("./assets/Montserrat-Italic.ttf");
-const fontMontserratItalicWoff = require("./assets/Montserrat-Italic.woff");
-const fontMontserratItalicWoff2 = require("./assets/Montserrat-Italic.woff2");
+import fontMontserratItalicTtf from "./assets/Montserrat-Italic.ttf";
+import fontMontserratItalicWoff from "./assets/Montserrat-Italic.woff";
+import fontMontserratItalicWoff2 from "./assets/Montserrat-Italic.woff2";
 
-const fontOswaldRegularTtf = require("./assets/Oswald-Regular.ttf");
-const fontOswaldRegularWoff = require("./assets/Oswald-Regular.woff");
-const fontOswaldRegularWoff2 = require("./assets/Oswald-Regular.woff2");
+import fontOswaldRegularTtf from "./assets/Oswald-Regular.ttf";
+import fontOswaldRegularWoff from "./assets/Oswald-Regular.woff";
+import fontOswaldRegularWoff2 from "./assets/Oswald-Regular.woff2";
 
-const fontOswaldSemiBoldTtf = require("./assets/Oswald-SemiBold.ttf");
-const fontOswaldSemiBoldWoff = require("./assets/Oswald-SemiBold.woff");
-const fontOswaldSemiBoldWoff2 = require("./assets/Oswald-SemiBold.woff2");
+import fontOswaldSemiBoldTtf from "./assets/Oswald-SemiBold.ttf";
+import fontOswaldSemiBoldWoff from "./assets/Oswald-SemiBold.woff";
+import fontOswaldSemiBoldWoff2 from "./assets/Oswald-SemiBold.woff2";
 
 const fonts = [
   {


### PR DESCRIPTION
## Related Jira ticket 🎫
[SC-23](https://smartcookie.atlassian.net/browse/SC-23)


## Implementation details 🕵️
Fix fonts imports.

We were using:
```javascript
const fontMontserratItalicTtf = require("./assets/Montserrat-Italic.ttf");
```
Now using 
```javascript
import fontMontserratItalicTtf from "./assets/Montserrat-Italic.ttf";
```
Add fonts.d.ts file to declare font types


