### PR TITLE
[SC-25] Addapt create-component script to inherit ts types (skip ci)

### DIFF
--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -56,7 +56,7 @@ fs.readdir(COMPONENT_TEMPLATE_FOLDER, (err, filenames) => {
         fileData = replaceIndex(
           fileData,
           "Component",
-          [2, 3, 4, 5, 6, 8, 10, 11, 12, 13],
+          [2, 3, 4, 5, 7, 9, 10, 11, 12],
           camelCaseComponentName
         );
         fileData = fileData.replace("storyType", capitalizeFirstLetter(type));

--- a/src/components/headline/headline.styles.tsx
+++ b/src/components/headline/headline.styles.tsx
@@ -76,7 +76,7 @@ export const sizes = {
 };
 
 // *** Components ***
-export const Headline = styled.h2<HeadlineTransientProps>`
+const Headline = styled.h2<HeadlineTransientProps>`
   ${baseHeadline};
   ${({ $size }) => $size && sizes[$size]};
 

--- a/src/components/headline/headline.styles.tsx
+++ b/src/components/headline/headline.styles.tsx
@@ -76,7 +76,7 @@ export const sizes = {
 };
 
 // *** Components ***
-const Headline = styled.h2<HeadlineTransientProps>`
+export const Headline = styled.h2<HeadlineTransientProps>`
   ${baseHeadline};
   ${({ $size }) => $size && sizes[$size]};
 

--- a/templates/component/component.stories.tsx
+++ b/templates/component/component.stories.tsx
@@ -25,7 +25,7 @@ export default {
           <Description>MDX description</Description>
           <Primary />
           <ArgsTable story={PRIMARY_STORY} />
-          <Stories title='Component variants' />
+          <Stories title='References' />
         </>
       ),
     },

--- a/templates/component/component.styles.ts
+++ b/templates/component/component.styles.ts
@@ -1,3 +1,0 @@
-import styled from "styled-components";
-
-export const Container = styled.div``;

--- a/templates/component/component.styles.tsx
+++ b/templates/component/component.styles.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+const Container = styled.div``;
+
+export const Styled = {
+  Container,
+};

--- a/templates/component/component.tsx
+++ b/templates/component/component.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import * as S from "./component.styles";
+import { Styled } from "./component.styles";
 import { ComponentProps } from "./component.types";
 
 const Component: React.FC<ComponentProps> = () => {
-  return <S.Container>Container</S.Container>;
+  return <Styled.Container>Container</Styled.Container>;
 };
+
+Component.displayName = "Component";
 
 export default Component;

--- a/templates/component/component.types.ts
+++ b/templates/component/component.types.ts
@@ -1,5 +1,4 @@
-import { ReactNode } from "react";
-
 export type ComponentProps = {
-  children: ReactNode;
+  /** Content of the --- */
+  children: React.ReactNode;
 };


### PR DESCRIPTION
## Related Jira ticket 🎫
[SC-25](https://smartcookie.atlassian.net/browse/SC-25)


## Implementation details 🕵️
Create component script was creating a component template without including typescript `type` definition in storybook documentation.

In this implementation, we add some fixes to implement typescript `types`


