### PR TITLE
[SC-24] Enable rollup to bundle multiple folders

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,39 +6,74 @@ import url from "@rollup/plugin-url";
 import { terser } from "rollup-plugin-terser";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 
+const fs = require("fs");
 const packageJson = require("./package.json");
+
+const plugins = [
+  peerDepsExternal(),
+  resolve(),
+  commonjs(),
+
+  typescript({
+    tsconfig: "./tsconfig.json",
+  }),
+  url({
+    include: ["**/*.woff", "**/*.woff2", "**/*.ttf"],
+    limit: Infinity,
+  }),
+  terser(),
+];
+
+const getFolders = (entry) => {
+  // get the names of folders and files of the entry directory
+  const dirs = fs.readdirSync(entry);
+  // do not include folders not meant for export and do not process index.ts
+  // ['Accordion', 'Button'...]
+  return dirs.filter((name) => name !== "index.ts").filter((name) => name !== "utils");
+};
+
+//loop through your folders and generate a rollup obj per folder
+const folderBuilds = getFolders("./src").flatMap((folder) => {
+  console.log(folder);
+  return [
+    {
+      input: `src/${folder}/index.ts`,
+      output: {
+        // ensure file destination is same as where the typings are
+        file: `dist/${folder}/index.js`,
+        sourcemap: true,
+        exports: "named",
+      },
+      plugins,
+      external: ["styled-components"],
+    },
+    // {
+    //   input: `dist/${folder}/index.js`,
+    //   output: { file: `dist/${folder}/index.d.ts`, format: "esm" },
+    //   plugins: [dts()],
+    // },
+  ];
+});
 
 export default [
   {
-    input: "src/index.ts",
+    input: ["src/index.ts"],
     output: [
-      {
-        file: packageJson.main,
-        format: "cjs",
-        sourcemap: true,
-      },
       {
         file: packageJson.module,
         format: "esm",
         sourcemap: true,
       },
+      {
+        file: packageJson.main,
+        format: "cjs",
+        sourcemap: true,
+      },
     ],
-    plugins: [
-      peerDepsExternal(),
-      resolve(),
-      commonjs(),
-
-      typescript({
-        tsconfig: "./tsconfig.json",
-      }),
-      url({
-        include: ["**/*.woff", "**/*.woff2", "**/*.ttf"],
-        limit: Infinity,
-      }),
-      terser(),
-    ],
+    plugins,
     external: ["styled-components"],
   },
+  ...folderBuilds,
   {
     input: "dist/esm/types/index.d.ts",
     output: [{ file: "dist/index.d.ts", format: "esm" }],


### PR DESCRIPTION
## Related Jira ticket 🎫
[SC-24](https://smartcookie.atlassian.net/browse/SC-24)


## Implementation details 🕵️
Enable rollup bundle to separate elements by folders:
- Components
- Global-styles
- Tokens
