### PR TITLE
[SC-30] Add Theme Provider and absolute imports (skip ci)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,7 @@
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
+
 module.exports = {
-  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ["../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
@@ -9,7 +11,16 @@ module.exports = {
   ],
   framework: "@storybook/react",
   core: {
-    builder: "@storybook/builder-webpack5",
+    builder: "webpack5",
+  },
+  webpackFinal: async (config) => {
+    config.resolve.plugins = [
+      ...(config.resolve.plugins || []),
+      new TsconfigPathsPlugin({
+        extensions: config.resolve.extensions,
+      }),
+    ];
+    return config;
   },
   features: {
     previewMdx2: true,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { GlobalStyles } from "./../src/global-styles";
+import { GlobalStyles, Theme } from "../src/global-styles";
+import styled from "styled-components";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -10,14 +11,72 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  layout: "fullscreen",
+};
+const ThemeBlock = styled.div`
+  width: 100%;
+  height: 100%;
+  bottom: 0;
+  overflow: auto;
+  padding: 32px;
+  background: ${(props) => props.theme.backgroundScreen};
+`;
+
+const withTheme = (StoryFn, context) => {
+  const { theme } = context.globals;
+  switch (theme) {
+    case "side-by-side": {
+      return (
+        <>
+          <Theme theme={"light"}>
+            <GlobalStyles />
+            <ThemeBlock left>
+              <MemoryRouter>
+                <StoryFn />
+              </MemoryRouter>
+            </ThemeBlock>
+          </Theme>
+          <Theme theme={"dark"}>
+            <GlobalStyles />
+            <ThemeBlock>
+              <MemoryRouter>
+                <StoryFn />
+              </MemoryRouter>
+            </ThemeBlock>
+          </Theme>
+        </>
+      );
+    }
+    default: {
+      return (
+        <Theme theme={theme}>
+          <GlobalStyles />
+          <ThemeBlock fill>
+            <MemoryRouter>
+              <StoryFn />
+            </MemoryRouter>
+          </ThemeBlock>
+        </Theme>
+      );
+    }
+  }
 };
 
-export const decorators = [
-  (Story) => (
-    <GlobalStyles>
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
-    </GlobalStyles>
-  ),
-];
+export const globalTypes = {
+  theme: {
+    name: "Theme",
+    description: "Global theme for components",
+    defaultValue: "side-by-side",
+    toolbar: {
+      icon: "circlehollow",
+      items: [
+        { value: "light", icon: "circlehollow", title: "light" },
+        { value: "dark", icon: "circle", title: "dark" },
+        { value: "side-by-side", icon: "sidebar", title: "side by side" },
+      ],
+      showName: true,
+    },
+  },
+};
+
+export const decorators = [withTheme];

--- a/__mocks__/file-mock.js
+++ b/__mocks__/file-mock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,0 +1,3 @@
+export { iconArgs } from "./icon-args";
+export { setPropDocumentation } from "./set-prop-documentation";
+export { noCanvas } from "./stories-helpers";

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,14 @@
 module.exports = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["./jest-setup.js"],
+  moduleNameMapper: {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+      "<rootDir>/__mocks__/file-mock.js",
+    "@global-styles": "<rootDir>/src/global-styles/index.ts",
+    "@tokens": "<rootDir>/src/tokens/index.ts",
+    "@components": "<rootDir>/src/components/index.ts",
+    "@styles": ["<rootDir>/src/styles/index.ts"],
+    "@helpers": ["<rootDir>/helpers/index.ts"],
+    "@test-utils": ["<rootDir>/test-utils.tsx"],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.32.1",
+        "tsconfig-paths-webpack-plugin": "^4.0.0",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4"
       },
@@ -31028,6 +31029,110 @@
         }
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
+      "integrity": "sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -56672,6 +56777,87 @@
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
+    },
+    "tsconfig-paths": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
+      "integrity": "sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.32.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.0",
     "tslib": "^2.4.0",
     "typescript": "^4.7.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,17 @@ const plugins = [
   typescript({
     tsconfig: "./tsconfig.json",
     useTsconfigDeclarationDir: true,
+    tsconfigOverride: {
+      exclude: [
+        "./templates",
+        "./helpers",
+        "./shared",
+        "./dist/**/*",
+        "**/*.test.js",
+        "**/*.stories.tsx",
+        "./test-utils.tsx",
+      ],
+    },
   }),
   url({
     include: ["**/*.woff", "**/*.woff2", "**/*.ttf"],

--- a/shared/design-tokens-document-table/index.ts
+++ b/shared/design-tokens-document-table/index.ts
@@ -1,0 +1,1 @@
+export { DesignSystemDocumentTable } from "./design-tokens-document-table";

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,1 @@
+export { DesignSystemDocumentTable } from "./design-tokens-document-table";

--- a/src/components/body/body.stories.tsx
+++ b/src/components/body/body.stories.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import styled from "styled-components";
+
 import { Body } from "./body";
-import { BodyCopySize, BodyCopyFontWeight } from "./body.types";
+import { BodyCopySize, BodyCopyFontWeight, BodyCopyLineHeight } from "./body.types";
 import { fontWeights, lineHeights, sizes } from "./body.styles";
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
+
+import { setPropDocumentation, noCanvas } from "@helpers";
+import { scale160, space4XL, spaceM } from "@tokens";
 
 import {
   Title,
@@ -14,10 +17,7 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
-import styled from "styled-components";
-import { scale120, scale160, space4XL, spaceM } from "../../tokens";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { BodyCopyLineHeight } from "./body.types";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 const bodySizes: string[] = Object.keys(sizes);
 const bodyWeights: string[] = Object.keys(fontWeights);

--- a/src/components/body/body.styles.ts
+++ b/src/components/body/body.styles.ts
@@ -1,9 +1,17 @@
 import styled, { css } from "styled-components";
 
-import { mediaConfined, mediaWide } from "../../tokens";
-
-import { scale060, scale070, scale080, scale090, scale100 } from "../../tokens/scale";
-import { spaceM, spaceS, spaceL } from "../../tokens/spacing";
+import {
+  scale060,
+  scale070,
+  scale080,
+  scale090,
+  scale100,
+  spaceM,
+  spaceS,
+  spaceL,
+  mediaConfined,
+  mediaWide,
+} from "@tokens";
 
 import type { BodyCopyFontWeight, BodyCopyLineHeight, BodyCopySize } from "./body.types";
 
@@ -19,6 +27,7 @@ type BodyTransientProps = {
 
 // *** Base ***
 const baseBodyCopy = css`
+  color: ${({ theme }) => theme.typography.bodyTextColor};
   line-height: 1.5;
   margin-left: 0;
   margin-right: 0;

--- a/src/components/body/body.test.js
+++ b/src/components/body/body.test.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { render } from "@test-utils";
 import { Body } from "./body";
 
 describe(`Body`, () => {

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import styled from "styled-components";
+import { IoBarChartSharp } from "react-icons/io5";
+
 import { Button } from "./button";
 
 import {
@@ -11,16 +13,11 @@ import {
   Primary,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
-import styled from "styled-components";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { ButtonSizes } from "./button.types";
-import { Headline } from "../headline/headline";
-import { scale100 } from "../../tokens";
-import { iconArgs } from "../../../helpers/icon-args";
-import { IoBarChartSharp, IoAccessibilitySharp } from "react-icons/io5";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import { noCanvas, iconArgs, setPropDocumentation } from "@helpers";
+import { spaceXL } from "@tokens";
+
 export default {
   title: "Component/Button",
   component: Button,
@@ -46,6 +43,7 @@ export default {
     theme: { table: { disable: true } },
     as: { table: { disable: true } },
     forwardedAs: { table: { disable: true } },
+    innerRef: { table: { disable: true } },
     icon: iconArgs,
     children: setPropDocumentation({ control: "text" }),
     to: setPropDocumentation({ control: "text" }),
@@ -68,162 +66,73 @@ Default.args = {
 
 const Container = styled.div`
   display: flex;
-  flex-direction: column;
-  gap: 10px;
-`;
-const SizeContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 40px;
-  margin-bottom: ${scale100};
+  gap: ${spaceXL};
 `;
 
-const HeadlineComp = styled(Headline)``;
-
-const sizes = ["small", "medium", "large"];
-
-export const PrimaryVariant = () => {
+const ReferenceTemplate: ComponentStory<typeof Button> = (args) => {
   return (
     <Container>
-      {sizes.map((size) => {
-        return (
-          <>
-            <Headline noMargin>{size.charAt(0).toUpperCase() + size.slice(1)}</Headline>
-
-            <SizeContainer key={`primary_${size}`}>
-              <Button size={size as ButtonSizes} variant='primary'>
-                Primary{" "}
-              </Button>
-              <Button
-                size={size as ButtonSizes}
-                variant='primary'
-                icon={IoBarChartSharp}
-                iconSize={18}
-              >
-                Primary
-              </Button>
-              <Button
-                size={size as ButtonSizes}
-                variant='primary'
-                icon={IoBarChartSharp}
-                iconSize={18}
-              />
-              <Button size={size as ButtonSizes} variant='primary' loading icon={IoBarChartSharp}>
-                Primary
-              </Button>
-              <Button size={size as ButtonSizes} variant='primary' disabled>
-                Primary
-              </Button>
-            </SizeContainer>
-          </>
-        );
-      })}
+      <Button size='medium' variant={args.variant}>
+        {args.variant!.charAt(0).toUpperCase() + args.variant!.slice(1)}
+      </Button>
+      <Button size='medium' variant={args.variant} icon={args.icon} iconSize={args.iconSize}>
+        {args.variant!.charAt(0).toUpperCase() + args.variant!.slice(1)}
+      </Button>
+      <Button size='medium' variant={args.variant} icon={args.icon} iconSize={args.iconSize} />
+      <Button size='medium' variant={args.variant} loading icon={args.icon}>
+        {args.variant!.charAt(0).toUpperCase() + args.variant!.slice(1)}
+      </Button>
+      <Button size='medium' variant={args.variant} disabled>
+        {args.variant!.charAt(0).toUpperCase() + args.variant!.slice(1)}
+      </Button>
     </Container>
   );
 };
 
-export const SecondaryVariant = () => {
-  return (
-    <Container>
-      {sizes.map((size) => {
-        return (
-          <>
-            <Headline noMargin>{size.charAt(0).toUpperCase() + size.slice(1)}</Headline>
+export const PrimaryVariant = ReferenceTemplate.bind({});
+export const SecondaryVariant = ReferenceTemplate.bind({});
+export const TextVariant = ReferenceTemplate.bind({});
 
-            <SizeContainer key={`secondary_${size}`}>
-              <Button size={size as ButtonSizes} variant='secondary'>
-                Secondary{" "}
-              </Button>
-              <Button
-                size={size as ButtonSizes}
-                variant='secondary'
-                icon={IoBarChartSharp}
-                iconSize={18}
-              >
-                Secondary
-              </Button>
-              <Button
-                size={size as ButtonSizes}
-                variant='secondary'
-                icon={IoBarChartSharp}
-                iconSize={18}
-              />
-              <Button size={size as ButtonSizes} variant='secondary' loading icon={IoBarChartSharp}>
-                Secondary
-              </Button>
-              <Button size={size as ButtonSizes} variant='secondary' disabled>
-                Secondary
-              </Button>
-            </SizeContainer>
-          </>
-        );
-      })}
-    </Container>
-  );
+PrimaryVariant.args = {
+  variant: "primary",
+  icon: IoBarChartSharp,
+  iconSize: 18,
 };
-
-export const TextVariant = () => {
-  return (
-    <Container>
-      {sizes.map((size) => {
-        return (
-          <>
-            <Headline noMargin>{size.charAt(0).toUpperCase() + size.slice(1)}</Headline>
-
-            <SizeContainer key={`text_${size}`}>
-              <Button size={size as ButtonSizes} variant='text'>
-                Text{" "}
-              </Button>
-              <Button
-                size={size as ButtonSizes}
-                variant='text'
-                icon={IoBarChartSharp}
-                iconSize={18}
-              >
-                Text
-              </Button>
-              <Button
-                size={size as ButtonSizes}
-                variant='text'
-                icon={IoBarChartSharp}
-                iconSize={18}
-              />
-              <Button size={size as ButtonSizes} variant='text' loading icon={IoBarChartSharp}>
-                Text
-              </Button>
-              <Button size={size as ButtonSizes} variant='text' disabled>
-                Text
-              </Button>
-            </SizeContainer>
-          </>
-        );
-      })}
-    </Container>
-  );
-};
-
 PrimaryVariant.parameters = {
   ...noCanvas,
+
   docs: {
     description: {
-      story: "`Button` component primary variant with it's states and sizes",
+      story: "`Button` component **primary** variant with it's states",
     },
   },
+};
+
+SecondaryVariant.args = {
+  variant: "secondary",
+  icon: IoBarChartSharp,
+  iconSize: 18,
 };
 SecondaryVariant.parameters = {
   ...noCanvas,
   docs: {
     description: {
-      story: "`Button` component secondary variant with it's states and sizes",
+      story: "`Button` component **secondary** variant with it's states",
     },
   },
+};
+
+TextVariant.args = {
+  variant: "text",
+  icon: IoBarChartSharp,
+  iconSize: 18,
 };
 TextVariant.parameters = {
   ...noCanvas,
   docs: {
     description: {
-      story: "`Button` component text variant with it's states and sizes",
+      story: "`Button` component **text** variant with it's states",
     },
   },
 };

--- a/src/components/button/button.styles.tsx
+++ b/src/components/button/button.styles.tsx
@@ -1,4 +1,8 @@
 import { Link } from "react-router-dom";
+import styled, { css } from "styled-components";
+
+import { DotLoading } from "../dot-loading";
+
 import {
   borderRadiusS,
   mediaConfined,
@@ -9,19 +13,15 @@ import {
   mediaWide,
   motionEasingStandard,
   motionTimeXS,
-  gray300,
-  gray400,
-  gray200,
   scale140,
   scale160,
   scale150,
-  primary400,
-} from "../../tokens";
-import styled, { css } from "styled-components";
+} from "@tokens";
+
 import { ButtonSizes, ButtonVariants } from "./button.types";
 
-import { ring } from "../../styles/ring";
-import { DotLoading } from "../dot-loading";
+import { ring } from "@styles";
+
 type ButtonTransientProps = {
   $ellipsis?: boolean;
   $iconOnly: boolean;
@@ -106,16 +106,16 @@ export const variants = {
     background-color: ${primary};
 
     &:hover {
-      background-color: ${primary400};
+      background-color: ${({ theme }) => theme.button.primary.hoverBackgroundColor};
     }
 
     &:focus-visible {
-      ${ring({ color: primary })}
+      ${({ theme }) => ring({ color: primary, offsetColor: theme.backgroundScreen })}
     }
 
     &:active {
-      color: white;
-      background-color: black;
+      color: ${({ theme }) => theme.color.invertedNeutral};
+      background-color: ${({ theme }) => theme.color.neutral};
       transform: scale(0.98);
     }
   `,
@@ -123,39 +123,45 @@ export const variants = {
     background-color: transparent;
     border-width: 2px;
     border-style: solid;
-    border-color: black;
-    color: black;
+    border-color: ${({ theme }) => theme.color.neutral};
+    color: ${({ theme }) => theme.color.neutral};
 
     &:hover {
-      background-color: ${gray200};
+      background-color: ${({ theme }) => theme.button.secondary.hoverBackgroundColor};
     }
     &:focus-visible {
-      ${ring({ color: primary })}
+      ${({ theme }) => ring({ color: primary, offsetColor: theme.backgroundScreen })}
     }
 
     &:active {
-      color: white;
-      background-color: black;
+      color: ${({ theme }) => theme.color.invertedNeutral};
+      background-color: ${({ theme }) => theme.color.neutral};
       transform: scale(0.98);
     }
   `,
   text: css`
+    color: ${({ theme }) => theme.color.neutral};
     padding: 0px !important;
+    height: 100% !important;
   `,
 };
 
 export const disabled = {
   primary: css`
-    background-color: ${gray300};
-    color: ${gray400};
+    background-color: ${({ theme }) => theme.button.primary.disabledBackgroundColor};
+    color: ${({ theme }) => theme.button.primary.disabledTextColor};
     cursor: not-allowed;
   `,
   secondary: css`
-    border: 2px solid ${gray300};
-    color: ${gray400};
+    border: 2px solid ${({ theme }) => theme.button.secondary.disabledBorderColor};
+    color: ${({ theme }) => theme.button.secondary.disabledTextColor};
     cursor: not-allowed;
   `,
-  text: css``,
+  text: css`
+    color: ${({ theme }) => theme.button.text.disabledTextColor};
+    padding: 0px !important;
+    height: 100% !important;
+  `,
 };
 
 // *** Icon ***

--- a/src/components/button/button.test.js
+++ b/src/components/button/button.test.js
@@ -1,10 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { Router } from "react-router-dom";
+import { createMemoryHistory } from "history";
 
 import { Button } from "./button";
-import { Router } from "react-router-dom";
 
-import { createMemoryHistory } from "history";
+import { screen, fireEvent } from "@testing-library/react";
+import { render } from "@test-utils";
 
 const renderComponent = ({ children = "button", ...props } = {}) => {
   const history = createMemoryHistory();

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+
 import { Styled } from "./button.styles";
 import { ButtonProps } from "./button.types";
+
 export const Button: React.FC<ButtonProps> = ({
   children,
   disabled = false,
@@ -42,7 +44,7 @@ export const Button: React.FC<ButtonProps> = ({
     <Styled.InnerContent>
       {loading && (
         <Styled.LoadingContainer aria-hidden='true'>
-          <Styled.Loading size={size} />
+          <Styled.Loading size={size} disabled={disabled || loading} />
         </Styled.LoadingContainer>
       )}
       {Icon && (

--- a/src/components/button/button.types.ts
+++ b/src/components/button/button.types.ts
@@ -1,5 +1,4 @@
 import { Styled, sizes, variants } from "./button.styles";
-import { Button } from "./button";
 
 export type ButtonSizes = keyof typeof sizes;
 export type ButtonVariants = keyof typeof variants;

--- a/src/components/caption/caption.stories.tsx
+++ b/src/components/caption/caption.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Caption } from "./caption";
+import styled from "styled-components";
 
 import {
   Title,
@@ -11,15 +10,15 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
 import { fontWeights, lineHeights } from "./caption.styles";
-import { scale080, scale360, space4XL, spaceM } from "../../tokens";
-import styled from "styled-components";
 import { CaptionFontWeight, CaptionLineHeight } from "./caption.types";
-import { noCanvas } from "../../../helpers/stories-helpers";
+import { Caption } from "./caption";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import { setPropDocumentation, noCanvas } from "@helpers";
+import { scale080, scale360, space4XL, spaceM } from "@tokens";
+
 export default {
   title: "Typography/Caption",
   component: Caption,
@@ -50,7 +49,6 @@ export default {
 const Template: ComponentStory<typeof Caption> = (args) => <Caption {...args} />;
 
 export const Default = Template.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Default.args = {
   children: "This is a caption text",
   fontWeight: "regular",

--- a/src/components/caption/caption.styles.tsx
+++ b/src/components/caption/caption.styles.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from "styled-components";
 
-import { scale050 } from "../../tokens";
-
 import type { CaptionFontWeight, CaptionLineHeight } from "./caption.types";
+
+import { scale050 } from "@tokens";
 
 type CaptionTransientProps = {
   $ellipsis?: boolean;
@@ -13,6 +13,7 @@ type CaptionTransientProps = {
 
 // *** Base ***
 const baseCaption = css`
+  color: ${({ theme }) => theme.typography.captionTextColor};
   font-size: ${scale050};
   line-height: 1.5;
   margin-left: 0;

--- a/src/components/caption/caption.test.js
+++ b/src/components/caption/caption.test.js
@@ -1,7 +1,9 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
 
 import { Caption } from "./caption";
+
+import { screen } from "@testing-library/react";
+import { render } from "@test-utils";
 
 describe(`Caption`, () => {
   test("renders Caption", () => {

--- a/src/components/dot-loading/dot-loading.stories.tsx
+++ b/src/components/dot-loading/dot-loading.stories.tsx
@@ -1,8 +1,4 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { DotLoading as DotLoadingComponent } from "./dot-loading";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
 
 import {
   Title,
@@ -10,11 +6,14 @@ import {
   Description,
   Primary,
   ArgsTable,
-  Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import { DotLoading as DotLoadingComponent } from "./dot-loading";
+
+import { noCanvas, setPropDocumentation } from "@helpers";
+
 export default {
   title: "Component/Dot Loading",
   component: DotLoadingComponent,

--- a/src/components/dot-loading/dot-loading.styles.tsx
+++ b/src/components/dot-loading/dot-loading.styles.tsx
@@ -1,17 +1,12 @@
-import {
-  scale040,
-  scale050,
-  scale060,
-  scale100,
-  scale030,
-  scale080,
-  scale110,
-} from "../../../src/tokens";
 import styled, { css, keyframes } from "styled-components";
+
 import { DotLoadingSizes } from "./dot-loading.types";
+
+import { scale040, scale050, scale060, scale100, scale030, scale080, scale110 } from "@tokens";
 
 type DotLoadingTransientProps = {
   $size: DotLoadingSizes;
+  $disabled?: boolean;
 };
 
 const movementPx = {
@@ -80,41 +75,30 @@ const ellipsis3 = keyframes`
     transform: scale(0);
   }`;
 
-const Loader = styled.div<DotLoadingTransientProps>`
-  display: inline-flex;
-  position: relative;
-  ${({ $size }) => sizes[$size]}
+const Loader = styled.div<DotLoadingTransientProps>(
+  ({ $size }) => css`
+    display: inline-flex;
+    position: relative;
+    ${sizes[$size]}
+    div:nth-child(1) {
+      left: ${initialPx[$size]};
+      animation: ${ellipsis1} 0.6s infinite;
+    }
 
-  div:nth-child(1) {
-    ${({ $size }) =>
-      css`
-        left: ${initialPx[$size]};
-      `}
-    animation: ${ellipsis1} 0.6s infinite;
-  }
-
-  div:nth-child(2) {
-    ${({ $size }) =>
-      css`
-        left: ${initialPx[$size]};
-        animation: ${ellipsis2($size)} 0.6s infinite;
-      `}
-  }
-  div:nth-child(3) {
-    ${({ $size }) =>
-      css`
-        left: calc(${initialPx[$size]} + ${movementPx[$size]});
-        animation: ${ellipsis2($size)} 0.6s infinite;
-      `}
-  }
-  div:nth-child(4) {
-    ${({ $size }) =>
-      css`
-        left: calc(${initialPx[$size]} + ${movementPx[$size]} * 2);
-      `}
-    animation: ${ellipsis3} 0.6s infinite;
-  }
-`;
+    div:nth-child(2) {
+      left: ${initialPx[$size]};
+      animation: ${ellipsis2($size)} 0.6s infinite;
+    }
+    div:nth-child(3) {
+      left: calc(${initialPx[$size]} + ${movementPx[$size]});
+      animation: ${ellipsis2($size)} 0.6s infinite;
+    }
+    div:nth-child(4) {
+      left: calc(${initialPx[$size]} + ${movementPx[$size]} * 2);
+      animation: ${ellipsis3} 0.6s infinite;
+    }
+  `
+);
 
 const LoaderDot = styled.div<DotLoadingTransientProps>`
   position: absolute;
@@ -122,7 +106,8 @@ const LoaderDot = styled.div<DotLoadingTransientProps>`
   left: 0;
   ${({ $size }) => dotSizes[$size]}
   border-radius: 50%;
-  background: black;
+  background: ${({ theme, $disabled }) =>
+    $disabled ? theme.dotLoading.disabledColor : theme.color.neutral};
   animation-timing-function: cubic-bezier(0, 1, 1, 0);
 `;
 

--- a/src/components/dot-loading/dot-loading.test.js
+++ b/src/components/dot-loading/dot-loading.test.js
@@ -1,7 +1,8 @@
 import React from "react";
-import { render } from "@testing-library/react";
 
 import { DotLoading } from "./dot-loading";
+
+import { render } from "@test-utils";
 
 describe(`DotLoading`, () => {
   test("renders DotLoading", () => {

--- a/src/components/dot-loading/dot-loading.tsx
+++ b/src/components/dot-loading/dot-loading.tsx
@@ -1,14 +1,15 @@
 import React from "react";
+
 import { Styled } from "./dot-loading.styles";
 import { DotLoadingProps } from "./dot-loading.types";
 
-export const DotLoading: React.FC<DotLoadingProps> = ({ size = "medium" }) => {
+export const DotLoading: React.FC<DotLoadingProps> = ({ size = "medium", disabled }) => {
   return (
     <Styled.Loader $size={size} data-testid='dot-loading'>
-      <Styled.LoaderDot $size={size} />
-      <Styled.LoaderDot $size={size} />
-      <Styled.LoaderDot $size={size} />
-      <Styled.LoaderDot $size={size} />
+      <Styled.LoaderDot $size={size} $disabled={disabled} />
+      <Styled.LoaderDot $size={size} $disabled={disabled} />
+      <Styled.LoaderDot $size={size} $disabled={disabled} />
+      <Styled.LoaderDot $size={size} $disabled={disabled} />
     </Styled.Loader>
   );
 };

--- a/src/components/dot-loading/dot-loading.types.ts
+++ b/src/components/dot-loading/dot-loading.types.ts
@@ -4,4 +4,6 @@ export type DotLoadingSizes = keyof typeof sizes;
 export type DotLoadingProps = React.ComponentProps<typeof Styled.Loader> & {
   /** Loader dimensions */
   size?: DotLoadingSizes;
+  /** Loader for disabled components */
+  disabled?: boolean;
 };

--- a/src/components/form-field/form-field.stories.tsx
+++ b/src/components/form-field/form-field.stories.tsx
@@ -1,11 +1,5 @@
 import React, { ChangeEvent, useState } from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { FormField as FormFieldComponent } from "./form-field";
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
-
 import { IoCaretUpCircle } from "react-icons/io5";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { FormFieldSize } from "./form-field.types";
 
 import {
   Title,
@@ -16,11 +10,13 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
-import styled from "styled-components";
-import { spaceXXL } from "../../tokens";
-import { iconArgs } from "../../../helpers/icon-args";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import { FormField as FormFieldComponent } from "./form-field";
+import { FormFieldSize } from "./form-field.types";
+
+import { noCanvas, setPropDocumentation, iconArgs } from "@helpers";
+
 export default {
   title: "Component/FormField",
   component: FormFieldComponent,
@@ -52,10 +48,6 @@ export default {
     sizeWide: setPropDocumentation({ control: "inline-radio" }),
   },
 } as ComponentMeta<typeof FormFieldComponent>;
-
-const FormFieldWrapper = styled.div`
-  margin-bottom: ${spaceXXL};
-`;
 
 const Template: ComponentStory<typeof FormFieldComponent> = ({
   id,
@@ -97,9 +89,6 @@ Default.args = {
   label: "Default label",
   id: "default",
   size: "medium",
-};
-Default.parameters = {
-  ...noCanvas,
 };
 
 export const WithIcon = Template.bind({});

--- a/src/components/form-field/form-field.styles.tsx
+++ b/src/components/form-field/form-field.styles.tsx
@@ -1,10 +1,11 @@
+import styled, { css } from "styled-components";
+
+import { FormFieldSize, FormFieldVariant } from "./form-field.types";
+
+import { Caption } from "../caption";
+
 import {
   borderRadiusS,
-  gray200,
-  gray300,
-  gray400,
-  gray500,
-  gray800,
   motionEasingEnter,
   motionTimeM,
   scale060,
@@ -22,11 +23,10 @@ import {
   scale260,
   spaceM,
   spaceXL,
+  mediaConfined,
+  mediaWide,
   red,
-} from "../../tokens";
-import styled, { css } from "styled-components";
-import { FormFieldSize, FormFieldVariant } from "./form-field.types";
-import { mediaConfined, mediaWide } from "../../tokens/media";
+} from "@tokens";
 
 type TextareaTransientProps = {
   $error?: boolean;
@@ -156,8 +156,6 @@ const baseLabel = (multiline?: boolean) => css`
   left: ${scale070};
   transform: translateY(-50%);
 
-  color: ${gray400};
-
   cursor: text;
 
   transition-property: top, left, padding, color, font-size;
@@ -170,7 +168,7 @@ const baseLabel = (multiline?: boolean) => css`
     position: absolute;
     width: ${borderWidth};
     height: 80%;
-    background-color: ${gray500};
+
     transform-origin: top;
 
     transform: scaleY(0) translateY(-50%);
@@ -192,10 +190,11 @@ const baseLabel = (multiline?: boolean) => css`
 
 const stateLabel = {
   enabled: css`
-    color: ${gray400};
+    color: ${({ theme }) => theme.formField.label.textColor};
   `,
   disabled: css`
-    color: ${gray800};
+    color: ${({ theme }) => theme.formField.label.disabledTextColor};
+
     cursor: not-allowed;
   `,
 };
@@ -219,14 +218,16 @@ const filledLabel = ($error?: boolean) => css`
   left: calc(${scale070} + ${borderWidth});
   padding: 0 10px;
 
-  background-color: white;
-  color: ${$error ? red : gray500};
+  background-color: ${({ theme }) => theme.backgroundScreen};
+  color: ${({ theme }) =>
+    $error ? theme.formField.errorColor : theme.formField.filledBorderColor} !important;
 
   transition-delay: 0ms;
 
   &::after,
   &::before {
-    background-color: ${$error ? red : gray500};
+    background-color: ${({ theme }) =>
+      $error ? theme.formField.errorColor : theme.formField.filledBorderColor};
 
     transform: scaleY(1) translateY(-50%);
     transition-duration: ${motionTimeM};
@@ -241,24 +242,26 @@ const baseInput = css`
   border: none;
   outline: none;
   border-radius: ${borderRadiusS};
+
+  color: ${({ theme }) => theme.color.neutral};
 `;
 
 const stateInput = {
   enabled: css`
-    background-color: ${gray200};
+    background-color: ${({ theme }) => theme.formField.input.backgroundColor};
     &:hover {
-      background-color: ${gray300};
+      background-color: ${({ theme }) => theme.formField.input.hoverBackgroundColor};
     }
   `,
   disabled: css`
-    background-color: ${gray500};
+    background-color: ${({ theme }) => theme.formField.input.disabledBackgroundColor};
     cursor: not-allowed;
   `,
 };
 
 const filledInput = ($error?: boolean) => css`
-  border: ${borderWidth} solid ${$error ? red : gray500};
-  background-color: white !important;
+  border: ${borderWidth} solid ${({ theme }) => ($error ? red : theme.formField.filledBorderColor)} !important;
+  background-color: ${({ theme }) => theme.backgroundScreen} !important;
   transition-delay: 0ms;
 
   &:hover {
@@ -267,8 +270,9 @@ const filledInput = ($error?: boolean) => css`
 `;
 
 /** Icon styles */
-const baseIcon = css`
-  color: ${gray500};
+const baseIcon = (filled?: boolean) => css`
+  color: ${({ theme }) => (filled ? theme.color.neutral : theme.formField.label.textColor)};
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -277,10 +281,6 @@ const baseIcon = css`
   top: 50%;
   left: calc(${spaceM});
   transform: translateY(-50%);
-`;
-
-const filledIcon = css`
-  color: black;
 `;
 
 const FormFieldContainer = styled.div`
@@ -380,12 +380,11 @@ const Label = styled.label<LabelTransientProps>`
 `;
 
 const IconWrapper = styled.div<IconTransientProps>`
-  ${baseIcon}
-  ${({ $hasFocus, $isFilled }) => ($hasFocus || $isFilled) && filledIcon}
+  ${({ $hasFocus, $isFilled }) => baseIcon($hasFocus || $isFilled)}
 `;
 
-const PasswordWrapper = styled.div`
-  color: ${gray500};
+const PasswordWrapper = styled.div<{ filled?: boolean }>`
+  color: ${({ theme, filled }) => (filled ? theme.color.neutral : theme.formField.label.textColor)};
 
   display: flex;
   align-items: center;
@@ -403,7 +402,10 @@ const ErrorMessageWrapper = styled.div`
   position: absolute;
   top: 100%;
   left: 0px;
-  color: ${red};
+`;
+
+const ErrorCaption = styled(Caption)`
+  color: ${({ theme }) => theme.formField.errorColor};
 `;
 
 export const Styled = {
@@ -414,5 +416,6 @@ export const Styled = {
   TextareaWrapper,
   IconWrapper,
   ErrorMessageWrapper,
+  ErrorCaption,
   PasswordWrapper,
 };

--- a/src/components/form-field/form-field.test.js
+++ b/src/components/form-field/form-field.test.js
@@ -1,10 +1,18 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-
+import { IoAccessibility } from "react-icons/io5";
 import { FormField } from "./form-field";
 
-const renderComponent = ({ value, ...args }) => {
-  render(<FormField value={value} {...args} />);
+import { render } from "@test-utils";
+import { screen, fireEvent } from "@testing-library/react";
+
+const onChangeMock = jest.fn();
+
+jest.mock("react-icons/io5", () => ({
+  IoAccessibility: () => <div data-testid='icon' />,
+}));
+
+const renderComponent = ({ ...args }) => {
+  render(<FormField label='formfield' id='formfield' onChange={onChangeMock} {...args} />);
 };
 
 describe(`FormField`, () => {
@@ -15,14 +23,41 @@ describe(`FormField`, () => {
   });
 
   it("should call onChange when typing", () => {
-    const onChangeMock = jest.fn();
+    renderComponent();
 
-    renderComponent({ label: "Label", id: "callOnChange", onChange: onChangeMock });
-
-    const input = screen.getByLabelText("Label");
+    const input = screen.getByLabelText("formfield");
 
     fireEvent.change(input, { target: { value: "test" } });
 
     expect(onChangeMock).toHaveBeenCalled();
+  });
+  it("should show icon", () => {
+    renderComponent({ icon: IoAccessibility });
+
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+  it("should show error message ", () => {
+    const errorMessage = "error message";
+    renderComponent({ error: true, errorMessage });
+
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("should show show/hide password on password variant", () => {
+    renderComponent({ variant: "password" });
+
+    expect(screen.getByTestId("formfield-password-switch")).toBeInTheDocument();
+  });
+
+  it("should toggle between text and password type on password variant", () => {
+    renderComponent({ variant: "password" });
+
+    const input = screen.getByLabelText("formfield");
+
+    expect(input).toHaveAttribute("type", "password");
+
+    fireEvent.click(screen.getByTestId("formfield-password-switch"));
+
+    expect(input).toHaveAttribute("type", "text");
   });
 });

--- a/src/components/form-field/form-field.tsx
+++ b/src/components/form-field/form-field.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Caption } from "../caption";
+import { BiShow, BiHide } from "react-icons/bi";
+
 import { Styled } from "./form-field.styles";
 import { FormFieldProps } from "./form-field.types";
-import { BiShow, BiHide } from "react-icons/bi";
 
 export const FormField: React.FC<FormFieldProps> = ({
   disabled,
@@ -112,13 +112,17 @@ export const FormField: React.FC<FormFieldProps> = ({
         </Styled.Label>
       )}
       {variant === "password" && !multiline && (
-        <Styled.PasswordWrapper onClick={() => setShowPassword(!showPassword)}>
+        <Styled.PasswordWrapper
+          data-testid='formfield-password-switch'
+          filled={isFilled || hasFocus}
+          onClick={() => setShowPassword(!showPassword)}
+        >
           {showPassword ? <BiShow size={18} /> : <BiHide size={18} />}
         </Styled.PasswordWrapper>
       )}
       {error && errorMessage && (
         <Styled.ErrorMessageWrapper>
-          <Caption noMargin>{errorMessage}</Caption>
+          <Styled.ErrorCaption noMargin>{errorMessage}</Styled.ErrorCaption>
         </Styled.ErrorMessageWrapper>
       )}
     </Styled.FormFieldContainer>

--- a/src/components/headline/headline.stories.tsx
+++ b/src/components/headline/headline.stories.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Headline } from "./headline";
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
+import styled from "styled-components";
 
 import {
   Title,
@@ -12,14 +10,15 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { noCanvas } from "../../../helpers/stories-helpers";
-import styled from "styled-components";
-import { scale160, space4XL, spaceM } from "../../tokens";
+import { Headline } from "./headline";
 import { sizes } from "./headline.styles";
 import { HeadlineSize } from "./headline.types";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import { scale160, space4XL, spaceM } from "@tokens";
+import { setPropDocumentation, noCanvas } from "@helpers";
+
 export default {
   title: "Typography/Headline",
   component: Headline,

--- a/src/components/headline/headline.styles.tsx
+++ b/src/components/headline/headline.styles.tsx
@@ -1,5 +1,7 @@
 import styled, { css } from "styled-components";
 
+import { HeadlineSize } from "./headline.types";
+
 import {
   mediaConfined,
   mediaWide,
@@ -11,9 +13,7 @@ import {
   scale130,
   spaceL,
   spaceM,
-} from "../../tokens";
-
-import { HeadlineSize } from "./headline.types";
+} from "@tokens";
 
 type HeadlineTransientProps = {
   $ellipsis?: boolean;
@@ -25,6 +25,7 @@ type HeadlineTransientProps = {
 
 // *** Base ***
 const baseHeadline = css`
+  color: ${({ theme }) => theme.typography.headlineTextColor};
   font-weight: 700;
   line-height: 1.25;
   margin-left: 0;

--- a/src/components/headline/headline.test.js
+++ b/src/components/headline/headline.test.js
@@ -1,7 +1,9 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
 
 import { Headline } from "./headline";
+
+import { render } from "@test-utils";
+import { screen } from "@testing-library/react";
 
 describe(`Headline`, () => {
   test("renders Headline", () => {

--- a/src/components/headline/headline.tsx
+++ b/src/components/headline/headline.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import type { HeadlineProps } from "./headline.types";
-
 import { Styled } from "./headline.styles";
 
 export const Headline = ({

--- a/src/components/hero/hero.stories.tsx
+++ b/src/components/hero/hero.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Hero } from "./hero";
+import styled from "styled-components";
 
 import {
   Title,
@@ -11,14 +10,15 @@ import {
   Stories,
   PRIMARY_STORY,
 } from "@storybook/addon-docs";
-import { setPropDocumentation } from "../../../helpers/set-prop-documentation";
-import { noCanvas } from "../../../helpers/stories-helpers";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Hero } from "./hero";
 import { HeroSize, HeroFontWeight } from "./hero.types";
 import { fontWeights, sizes } from "./hero.styles";
-import { scale300, space4XL, spaceM } from "../../tokens";
-import styled from "styled-components";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import { scale300, space4XL, spaceM } from "@tokens";
+import { setPropDocumentation, noCanvas } from "@helpers";
+
 export default {
   title: "Typography/Hero",
   component: Hero,

--- a/src/components/hero/hero.styles.tsx
+++ b/src/components/hero/hero.styles.tsx
@@ -1,5 +1,7 @@
 import styled, { css } from "styled-components";
 
+import type { HeroFontWeight, HeroSize } from "./hero.types";
+
 import {
   mediaConfined,
   mediaWide,
@@ -11,9 +13,7 @@ import {
   scale220,
   spaceL,
   spaceXL,
-} from "../../tokens";
-
-import type { HeroFontWeight, HeroSize } from "./hero.types";
+} from "@tokens";
 
 type HeroTransientProps = {
   $noMargin?: boolean;
@@ -25,6 +25,8 @@ type HeroTransientProps = {
 
 // *** Base ***
 const baseHero = css`
+  color: ${({ theme }) => theme.typography.heroTextColor};
+
   font-family: "Oswald", "Trebuchet MS", Arial, "Helvetica Neue", sans-serif;
   margin-left: 0;
   margin-right: 0;

--- a/src/components/hero/hero.test.js
+++ b/src/components/hero/hero.test.js
@@ -1,7 +1,9 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
 
 import { Hero } from "./hero";
+
+import { render } from "@test-utils";
+import { screen } from "@testing-library/react";
 
 describe(`Hero`, () => {
   it("renders Hero", () => {

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Styled } from "./hero.styles";
 import { HeroProps } from "./hero.types";
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,5 +3,5 @@ export { Body } from "./body";
 export { Headline } from "./headline";
 export { Hero } from "./hero";
 export { Caption } from "./caption";
-export { DotLoading } from "./dot-loading"
-export { FormField } from "./form-field"
+export { DotLoading } from "./dot-loading";
+export { FormField } from "./form-field";

--- a/src/global-styles/base-styles.tsx
+++ b/src/global-styles/base-styles.tsx
@@ -1,4 +1,4 @@
-import { scale080, scale100, gray900 } from "./../tokens";
+import { scale080, scale100 } from "@tokens";
 import { createGlobalStyle } from "styled-components";
 
 export const BaseStyles = createGlobalStyle`

--- a/src/global-styles/index.ts
+++ b/src/global-styles/index.ts
@@ -1,1 +1,2 @@
+export { Theme } from "./theme";
 export { GlobalStyles } from "./global-styles";

--- a/src/global-styles/theme/index.ts
+++ b/src/global-styles/theme/index.ts
@@ -1,0 +1,1 @@
+export { Theme } from "./theme";

--- a/src/global-styles/theme/theme.tsx
+++ b/src/global-styles/theme/theme.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { ThemeProvider } from "styled-components";
+import { ThemeProps } from "./theme.types";
+import { darkTheme, lightTheme } from "./themes";
+
+export const Theme: React.FC<ThemeProps> = ({
+  children,
+  lightTheme: extraLightTheme,
+  darkTheme: extraDarkTheme,
+  theme: currentTheme,
+}) => {
+  const dark = extraDarkTheme ? { ...extraDarkTheme, ...darkTheme } : darkTheme;
+  const light = extraLightTheme ? { ...extraLightTheme, ...lightTheme } : lightTheme;
+
+  const theme = currentTheme === "light" ? light : dark;
+
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};

--- a/src/global-styles/theme/theme.types.tsx
+++ b/src/global-styles/theme/theme.types.tsx
@@ -1,0 +1,10 @@
+export type ThemeProps = {
+  /** Theme Provider content */
+  children?: React.ReactNode;
+  /** LightTheme from specific project */
+  lightTheme?: any;
+  /** DarkTheme from spicific project */
+  darkTheme?: any;
+  /** Theme */
+  theme: "light" | "dark";
+};

--- a/src/global-styles/theme/themes.ts
+++ b/src/global-styles/theme/themes.ts
@@ -1,0 +1,138 @@
+import { DefaultTheme } from "styled-components";
+import {
+  gray100,
+  gray200,
+  gray300,
+  gray400,
+  gray500,
+  gray600,
+  gray700,
+  gray800,
+  gray900,
+  primary400,
+  primary600,
+  red,
+  darkRed,
+} from "@tokens";
+
+import * as I from "./themes.types";
+
+declare module "styled-components" {
+  export interface DefaultTheme {
+    color: I.ColorType;
+    backgroundScreen: string;
+    typography: {
+      bodyTextColor: string;
+      headlineTextColor: string;
+      heroTextColor: string;
+      captionTextColor: string;
+    };
+    button: {
+      primary: I.PrimaryButtonTypes;
+      secondary: I.SecondaryButtonTypes;
+      text: I.TextButtonTypes;
+    };
+    dotLoading: {
+      disabledColor: string;
+    };
+    formField: {
+      filledBorderColor: string;
+      errorColor: string;
+      label: I.FormFieldLabelTyes;
+      input: I.FormFieldInputTypes;
+    };
+  }
+}
+
+export const lightTheme: DefaultTheme = {
+  color: {
+    neutral: "black",
+    invertedNeutral: "white",
+  },
+  backgroundScreen: "white",
+  typography: {
+    bodyTextColor: "black",
+    headlineTextColor: "black",
+    heroTextColor: "black",
+    captionTextColor: gray700,
+  },
+  dotLoading: {
+    disabledColor: gray400,
+  },
+  button: {
+    primary: {
+      hoverBackgroundColor: primary600,
+      disabledTextColor: gray400,
+      disabledBackgroundColor: gray300,
+    },
+    secondary: {
+      hoverBackgroundColor: gray200,
+      disabledTextColor: gray400,
+      disabledBorderColor: gray300,
+    },
+    text: {
+      disabledTextColor: gray400,
+    },
+  },
+
+  formField: {
+    filledBorderColor: gray500,
+    errorColor: red,
+    label: {
+      textColor: gray500,
+      disabledTextColor: gray800,
+    },
+    input: {
+      backgroundColor: gray200,
+      hoverBackgroundColor: gray300,
+      disabledBackgroundColor: gray500,
+    },
+  },
+};
+
+export const darkTheme: DefaultTheme = {
+  color: {
+    neutral: "white",
+    invertedNeutral: "black",
+  },
+  backgroundScreen: gray900,
+  typography: {
+    bodyTextColor: gray100,
+    headlineTextColor: "white",
+    heroTextColor: "white",
+    captionTextColor: gray300,
+  },
+  dotLoading: {
+    disabledColor: gray400,
+  },
+  button: {
+    primary: {
+      hoverBackgroundColor: primary400,
+      disabledTextColor: gray400,
+      disabledBackgroundColor: gray600,
+    },
+    secondary: {
+      hoverBackgroundColor: gray600,
+      disabledTextColor: gray400,
+      disabledBorderColor: gray600,
+    },
+    text: {
+      disabledTextColor: gray400,
+    },
+  },
+
+  formField: {
+    filledBorderColor: gray300,
+    errorColor: darkRed,
+
+    label: {
+      textColor: gray300,
+      disabledTextColor: gray800,
+    },
+    input: {
+      backgroundColor: gray700,
+      hoverBackgroundColor: gray600,
+      disabledBackgroundColor: gray500,
+    },
+  },
+};

--- a/src/global-styles/theme/themes.types.ts
+++ b/src/global-styles/theme/themes.types.ts
@@ -1,0 +1,29 @@
+export interface ColorType {
+  neutral: string;
+  invertedNeutral: string;
+}
+
+export interface PrimaryButtonTypes {
+  hoverBackgroundColor: string;
+  disabledTextColor: string;
+  disabledBackgroundColor: string;
+}
+export interface SecondaryButtonTypes {
+  hoverBackgroundColor: string;
+  disabledBorderColor: string;
+  disabledTextColor: string;
+}
+
+export interface TextButtonTypes {
+  disabledTextColor: string;
+}
+
+export interface FormFieldLabelTyes {
+  textColor: string;
+  disabledTextColor: string;
+}
+export interface FormFieldInputTypes {
+  backgroundColor: string;
+  hoverBackgroundColor: string;
+  disabledBackgroundColor: string;
+}

--- a/src/styles/ring.ts
+++ b/src/styles/ring.ts
@@ -1,5 +1,5 @@
 import { css } from "styled-components";
-import { scale010, spaceXXS } from "../tokens";
+import { scale010, spaceXXS } from "@tokens";
 
 type RingProps = {
   width?: string;

--- a/src/tokens/color.ts
+++ b/src/tokens/color.ts
@@ -155,6 +155,7 @@ export const gray800_RGBA: string = "46, 48, 57";
 export const gray900_RGBA: string = "31, 32, 40";
 
 //EXTRA
-/** Red color (HEX) token: **#ff4545** */ export const red: string = "#ff4545";
+/** Red color (HEX) token: **#cc0000** */ export const red: string = "#cc0000";
+/** Dark Red color (HEX) token: **#ff4d4d** */ export const darkRed: string = "#ff4d4d";
 /** Green color (HEX) token: **#68d94a** */ export const green: string = "#68d94a";
 /** Yellow color (HEX) token: **#ffd644** */ export const yellow: string = "#ffd644";

--- a/src/tokens/docs/border-redius.stories.tsx
+++ b/src/tokens/docs/border-redius.stories.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { ComponentMeta } from "@storybook/react";
-import * as borderRadiusTokens from "../borderRadius";
+import styled, { css } from "styled-components";
 
 import { Title, Subtitle, Primary } from "@storybook/addon-docs";
-import styled, { css } from "styled-components";
-import { primary } from "../../tokens";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { DesignSystemDocumentTable } from "../../../shared/design-tokens-document-table/design-tokens-document-table";
+import { ComponentMeta } from "@storybook/react";
+
+import * as borderRadiusTokens from "../borderRadius";
+
+import { primary } from "@tokens";
+import { noCanvas } from "@helpers";
+import { DesignSystemDocumentTable } from "@shared";
 
 export default {
   title: "Tokens/Border Radius",
@@ -37,7 +39,7 @@ const Preview = styled.div<PreviewProps>`
     `}
 `;
 
-const SpacingPreview = ({ tokenValue }) => {
+const SpacingPreview = ({ tokenValue }: { tokenValue: string }) => {
   return <Preview borderRadius={tokenValue} />;
 };
 

--- a/src/tokens/docs/media.stories.tsx
+++ b/src/tokens/docs/media.stories.tsx
@@ -1,13 +1,15 @@
 import React from "react";
+import styled from "styled-components";
+
 import { ComponentMeta } from "@storybook/react";
+import { Title, Subtitle, Primary } from "@storybook/addon-docs";
+
 import * as mediaQuerysTokens from "../media";
 
-import { Title, Subtitle, Primary } from "@storybook/addon-docs";
-import styled from "styled-components";
-import { gray900, spaceS } from "../../tokens";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { DesignSystemDocumentTable } from "../../../shared/design-tokens-document-table/design-tokens-document-table";
-import { Body } from "../../components";
+import { Body } from "@components";
+import { gray900, spaceS } from "@tokens";
+import { noCanvas } from "@helpers";
+import { DesignSystemDocumentTable } from "@shared";
 
 export default {
   title: "Tokens/Media Querys",
@@ -52,7 +54,7 @@ const Line = styled.div`
   background: ${gray900};
 `;
 
-const MediaQuerysPreview = ({ tokenValue }) => {
+const MediaQuerysPreview = ({ tokenValue }: { tokenValue: string }) => {
   let interval: Interval = { max: "♾️", min: "0px" };
 
   tokenValue.split("and").map((val) => {

--- a/src/tokens/docs/motion.stories.tsx
+++ b/src/tokens/docs/motion.stories.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { ComponentMeta } from "@storybook/react";
-import * as motionTokens from "../motion";
 
 import { Title, Subtitle, Primary } from "@storybook/addon-docs";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { DesignSystemDocumentTable } from "../../../shared/design-tokens-document-table/design-tokens-document-table";
-import { Caption } from "../../components/caption/caption";
+import { ComponentMeta } from "@storybook/react";
+
+import * as motionTokens from "../motion";
+
+import { Caption } from "@components";
+import { noCanvas } from "@helpers";
+import { DesignSystemDocumentTable } from "@shared";
 
 export default {
   title: "Tokens/Motion",

--- a/src/tokens/docs/scale.stories.tsx
+++ b/src/tokens/docs/scale.stories.tsx
@@ -1,12 +1,13 @@
 import React from "react";
+import styled, { css } from "styled-components";
+
 import { ComponentMeta } from "@storybook/react";
+import { Title, Subtitle, Primary } from "@storybook/addon-docs";
 import * as scaleTokens from "../scale";
 
-import { Title, Subtitle, Primary } from "@storybook/addon-docs";
-import styled, { css } from "styled-components";
-import { borderRadiusXS, primary } from "../../tokens";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { DesignSystemDocumentTable } from "../../../shared/design-tokens-document-table/design-tokens-document-table";
+import { borderRadiusXS, primary } from "@tokens";
+import { noCanvas } from "@helpers";
+import { DesignSystemDocumentTable } from "@shared";
 
 export default {
   title: "Tokens/Scale",
@@ -37,8 +38,8 @@ const Preview = styled.div<PreviewProps>`
   background-color: ${primary};
 `;
 
-const ScalePreview = ({ tokenValue }) => {
-  const width: number = (tokenValue.split("px")[0] / 432) * 100;
+const ScalePreview = ({ tokenValue }: { tokenValue: string }) => {
+  const width: number = (parseFloat(tokenValue.split("px")[0]) / 432) * 100;
   return <Preview width={`${width}%`} />;
 };
 

--- a/src/tokens/docs/shadow.stories.tsx
+++ b/src/tokens/docs/shadow.stories.tsx
@@ -1,12 +1,14 @@
 import React from "react";
+import styled, { css } from "styled-components";
+
 import { ComponentMeta } from "@storybook/react";
+import { Title, Subtitle, Primary } from "@storybook/addon-docs";
+
 import * as shadowTokens from "../shadow";
 
-import { Title, Subtitle, Primary } from "@storybook/addon-docs";
-import styled, { css } from "styled-components";
-import { borderRadiusS } from "../../tokens";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { DesignSystemDocumentTable } from "../../../shared/design-tokens-document-table/design-tokens-document-table";
+import { noCanvas } from "@helpers";
+import { borderRadiusS } from "@tokens";
+import { DesignSystemDocumentTable } from "@shared";
 
 export default {
   title: "Tokens/Shadow",
@@ -37,7 +39,7 @@ const Preview = styled.div<PreviewProps>`
     `}
 `;
 
-const SpacingPreview = ({ tokenValue }) => {
+const SpacingPreview = ({ tokenValue }: { tokenValue: string }) => {
   return <Preview shadow={tokenValue} />;
 };
 

--- a/src/tokens/docs/spacing.stories.tsx
+++ b/src/tokens/docs/spacing.stories.tsx
@@ -1,13 +1,15 @@
 import React from "react";
+import styled, { css } from "styled-components";
+
 import { ComponentMeta } from "@storybook/react";
+import { Title, Subtitle, Primary } from "@storybook/addon-docs";
+
 import * as spacingTokens from "../spacing";
 
-import { Title, Subtitle, Primary } from "@storybook/addon-docs";
-import styled, { css } from "styled-components";
-import { gray900 } from "../../tokens";
-import { noCanvas } from "../../../helpers/stories-helpers";
-import { DesignSystemDocumentTable } from "../../../shared/design-tokens-document-table/design-tokens-document-table";
-import { Body } from "../../components";
+import { Body } from "@components";
+import { gray900 } from "@tokens";
+import { noCanvas } from "@helpers";
+import { DesignSystemDocumentTable } from "@shared";
 
 export default {
   title: "Tokens/Spacing",
@@ -39,8 +41,8 @@ const Line = styled.div<{ width: string }>`
   background: ${gray900};
 `;
 
-const SpacingPreview = ({ tokenValue }) => {
-  const width: number = (tokenValue.split("px")[0] / 122) * 100;
+const SpacingPreview = ({ tokenValue }: { tokenValue: string }) => {
+  const width: number = (parseFloat(tokenValue.split("px")[0]) / 122) * 100;
   return (
     <Preview>
       <Body size='small' noMargin>

--- a/templates/component/component.test.js
+++ b/templates/component/component.test.js
@@ -1,5 +1,7 @@
 import React from "react";
-import { render } from "@testing-library/react";
+
+import { screen, fireEvent } from "@testing-library/react";
+import { render } from "@test-utils";
 
 import { Component } from "./component";
 

--- a/test-utils.tsx
+++ b/test-utils.tsx
@@ -1,0 +1,16 @@
+import React, { FC, ReactElement } from "react";
+import { render, RenderOptions } from "@testing-library/react";
+import { GlobalStyles, Theme } from "@global-styles";
+
+const AllTheProviders: FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <Theme theme='light'>
+      <GlobalStyles>{children}</GlobalStyles>
+    </Theme>
+  );
+};
+
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, "wrapper">) =>
+  render(ui, { wrapper: AllTheProviders, ...options });
+
+export { customRender as render };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,18 +19,14 @@
 
     "baseUrl": ".",
     "paths": {
-      "components/*": ["dist/*"],
-      "global-styles/*": ["dist/*"],
-      "tokens/*": ["dist/*"],
-      "styles/*": ["dist/*"]
+      "@components": ["src/components/index.ts"],
+      "@global-styles": ["src/global-styles/index.ts"],
+      "@tokens": ["src/tokens/index.ts"],
+      "@styles": ["./src/styles/index.ts"],
+      "@helpers": ["helpers/index.ts"],
+      "@test-utils": ["test-utils.tsx"],
+      "@shared": ["shared/index.ts"]
     }
   },
-  "exclude": [
-    "./templates",
-    "./helpers",
-    "./shared",
-    "./dist/**/*",
-    "**/*.test.js",
-    "**/*.stories.tsx"
-  ]
+  "exclude": ["./templates", "./dist/**/*"]
 }


### PR DESCRIPTION
## Related Jira ticket 🎫
[SC-30](https://smartcookie.atlassian.net/browse/SC-30)


## Implementation details 🕵️
Add `Theme` component to provide **dark** and **light** theme to SC projects.
Create `test-utils.tsx` file to support `Theme` in jest tests.

Add relative paths to:
- components
- tokens
- global-styles
- styles
- shared
- helpers
- test-utils

Update `rollup.config` to support absolute imports.
Update `jest.config` to support absolute imports.

## Checklist ✔️
- [x] Tests
- [x] Documentation

