### PR TITLE
[SC-35] Build select multiselect component (skip ci)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,7 +7,6 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
     "@storybook/addon-docs",
-    "@storybook/addon-a11y",
   ],
   framework: "@storybook/react",
   core: {

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,6 +1,8 @@
 // in .storybook/manager.js
 import addons from "@storybook/addons";
+import smartCookieTheme from "./smartcookieTheme";
 
 addons.setConfig({
   enableShortcuts: false,
+  theme: smartCookieTheme,
 });

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+// in .storybook/manager.js
+import addons from "@storybook/addons";
+
+addons.setConfig({
+  enableShortcuts: false,
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { GlobalStyles, Theme } from "../src/global-styles";
 import styled from "styled-components";
+import "../helpers/storybook.css";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -26,6 +27,9 @@ const Container = styled.div`
 `;
 const withTheme = (StoryFn, context) => {
   const { theme } = context.globals;
+
+  const story1Id = "1";
+  const story2Id = "2";
   switch (theme) {
     case "horizontal-side-by-side": {
       return (
@@ -33,13 +37,13 @@ const withTheme = (StoryFn, context) => {
           <Theme theme={"light"}>
             <GlobalStyles />
             <ThemeBlock left>
-              <StoryFn />
+              <StoryFn storyId={story1Id} />
             </ThemeBlock>
           </Theme>
           <Theme theme={"dark"}>
             <GlobalStyles />
             <ThemeBlock>
-              <StoryFn />
+              <StoryFn storyId={story2Id} />
             </ThemeBlock>
           </Theme>
         </MemoryRouter>
@@ -52,13 +56,13 @@ const withTheme = (StoryFn, context) => {
             <Theme theme={"light"}>
               <GlobalStyles />
               <ThemeBlock vertical>
-                <StoryFn />
+                <StoryFn storyId={story1Id} />
               </ThemeBlock>
             </Theme>
             <Theme theme={"dark"}>
               <GlobalStyles />
               <ThemeBlock vertical>
-                <StoryFn />
+                <StoryFn storyId={story2Id} />
               </ThemeBlock>
             </Theme>
           </Container>
@@ -84,7 +88,7 @@ export const globalTypes = {
   theme: {
     name: "Theme",
     description: "Global theme for components",
-    defaultValue: "light",
+    defaultValue: "vertical-side-by-side",
     toolbar: {
       icon: "circlehollow",
       items: [

--- a/.storybook/smartcookieTheme.js
+++ b/.storybook/smartcookieTheme.js
@@ -1,0 +1,11 @@
+import { create } from "@storybook/theming";
+
+export default create({
+  base: "light",
+  appBorderRadius: 8,
+
+  brandTitle: "SmartCookie Storybook",
+  brandUrl: "https://cookiecoaching.com",
+  brandImage: "https://storage.cloud.google.com/smartcookie_logos/SC_Logo.png",
+  brandTarget: "_self",
+});

--- a/helpers/storybook.css
+++ b/helpers/storybook.css
@@ -1,0 +1,3 @@
+.sbdocs-h2 {
+  margin-top: 30px !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "husky": "^8.0.1",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
+        "react-hook-form": "^7.34.2",
         "react-icons": "^4.4.0",
         "rollup": "^2.76.0",
         "rollup-plugin-dts": "^4.2.2",
@@ -27685,6 +27686,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.34.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.34.2.tgz",
+      "integrity": "sha512-1lYWbEqr0GW7HHUjMScXMidGvV0BE2RJV3ap2BL7G0EJirkqpccTaawbsvBO8GZaB3JjCeFBEbnEWI1P8ZoLRQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
@@ -54327,6 +54344,13 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-hook-form": {
+      "version": "7.34.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.34.2.tgz",
+      "integrity": "sha512-1lYWbEqr0GW7HHUjMScXMidGvV0BE2RJV3ap2BL7G0EJirkqpccTaawbsvBO8GZaB3JjCeFBEbnEWI1P8ZoLRQ==",
+      "dev": true,
+      "requires": {}
     },
     "react-icons": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "husky": "^8.0.1",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
+    "react-hook-form": "^7.34.2",
     "react-icons": "^4.4.0",
     "rollup": "^2.76.0",
     "rollup-plugin-dts": "^4.2.2",

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -56,7 +56,7 @@ fs.readdir(COMPONENT_TEMPLATE_FOLDER, (err, filenames) => {
         fileData = replaceIndex(
           fileData,
           "Component",
-          [2, 3, 4, 5, 7, 9, 10, 11, 12],
+          [2, 3, 4, 5, 6, 8, 10, 11, 12, 13],
           camelCaseComponentName
         );
         fileData = fileData.replace("storyType", capitalizeFirstLetter(type));

--- a/src/components/body/body.tsx
+++ b/src/components/body/body.tsx
@@ -11,6 +11,7 @@ export const Body: React.FC<BodyProps> = ({
   size = "medium",
   sizeConfined,
   sizeWide,
+  className,
   ...props
 }) => {
   return (
@@ -23,6 +24,7 @@ export const Body: React.FC<BodyProps> = ({
       $sizeConfined={sizeConfined}
       $sizeWide={sizeWide}
       data-xds='Body'
+      className={className}
       {...props}
     >
       {children}

--- a/src/components/body/body.types.ts
+++ b/src/components/body/body.types.ts
@@ -6,6 +6,8 @@ export type BodyCopyFontWeight = keyof typeof fontWeights;
 export type BodyProps = React.ComponentProps<typeof Styled.Body> & {
   /** Content of the body copy */
   children: React.ReactNode;
+  /** Custom css className */
+  className?: string;
   /** Activate text truncation */
   ellipsis?: boolean;
   /** Set font-weight */

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -12,6 +12,7 @@ import {
   Stories,
   Primary,
   PRIMARY_STORY,
+  Source,
 } from "@storybook/addon-docs";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
@@ -28,11 +29,16 @@ export default {
         <>
           <Title>Button</Title>
           <Subtitle>Button component for SC projects</Subtitle>
+          <Description>##Overview</Description>
           <Description>
             Basic `Button` component to perform navigation inside / outside the project or to
             perform `onClick` events
           </Description>
-          <Primary></Primary>
+
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { Button } from @smart-design/components`} />
+          <Description>###Example</Description>
+          <Primary />
           <ArgsTable story={PRIMARY_STORY} />
           <Stories title='References' />
         </>

--- a/src/components/button/button.styles.tsx
+++ b/src/components/button/button.styles.tsx
@@ -142,31 +142,41 @@ export const variants = {
     }
   `,
   text: css`
+    position: relative;
     color: ${({ theme }) => theme.color.neutral};
     padding: 0px !important;
-    height: auto !important;
-    border-radius: 0;
-    border-bottom: 1px solid transparent;
+    border-radius: 0 !important;
+    border-bottom: 2px solid transparent;
 
+    &:after {
+      content: "";
+      position: absolute;
+      width: 100%;
+      height: 2px;
+      top: calc(100% - 5px);
+      background-color: transparent;
+    }
     &:focus-visible {
-      border-bottom: ${({ theme }) => `1px solid ${theme.color.neutral}`};
+      &:after {
+        background-color: ${({ theme }) => theme.color.neutral};
+      }
     }
   `,
 };
 
 export const disabled = {
   primary: css`
-    background-color: ${({ theme }) => theme.button.primary.disabledBackgroundColor};
-    color: ${({ theme }) => theme.button.primary.disabledTextColor};
+    background-color: ${({ theme }) => theme.common.disabledBackgroundColor};
+    color: ${({ theme }) => theme.common.disabledSurfaceColor};
     cursor: not-allowed;
   `,
   secondary: css`
-    border: 2px solid ${({ theme }) => theme.button.secondary.disabledBorderColor};
-    color: ${({ theme }) => theme.button.secondary.disabledTextColor};
+    border: 2px solid ${({ theme }) => theme.common.disabledSurfaceColor};
+    color: ${({ theme }) => theme.common.disabledSurfaceColor};
     cursor: not-allowed;
   `,
   text: css`
-    color: ${({ theme }) => theme.button.text.disabledTextColor};
+    color: ${({ theme }) => theme.common.disabledSurfaceColor};
     padding: 0px !important;
     height: 100% !important;
   `,
@@ -187,10 +197,7 @@ const IconContainer = styled.div<IconContainerTransientProps>`
     `};
 `;
 
-type IconOnlyProps = {
-  size: ButtonSizes;
-};
-const iconOnly = ({ size }: IconOnlyProps) => css`
+const iconOnly = css`
   padding: 0;
   border-radius: 50%;
   & ${IconContainer} {
@@ -220,7 +227,7 @@ const Button = styled.button<ButtonTransientProps>`
       }
     `};
 
-  ${({ $iconOnly, $size }) => $iconOnly && iconOnly({ size: $size })};
+  ${({ $iconOnly }) => $iconOnly && iconOnly};
 `;
 
 const ExternalButton = styled.a<ButtonTransientProps>`
@@ -245,7 +252,7 @@ const ExternalButton = styled.a<ButtonTransientProps>`
       }
     `};
 
-  ${({ $iconOnly, $size }) => $iconOnly && iconOnly({ size: $size })};
+  ${({ $iconOnly }) => $iconOnly && iconOnly};
 `;
 
 const RouterButton = styled(Link)<ButtonTransientProps>`

--- a/src/components/dot-loading/dot-loading.stories.tsx
+++ b/src/components/dot-loading/dot-loading.stories.tsx
@@ -7,6 +7,7 @@ import {
   Primary,
   ArgsTable,
   PRIMARY_STORY,
+  Source,
 } from "@storybook/addon-docs";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
@@ -23,6 +24,8 @@ export default {
         <>
           <Title>Loader</Title>
           <Subtitle>Loading animation</Subtitle>
+
+          <Description>##Overview</Description>
           <Description>
             `DotLoading` component is the loading animation for SC projects. It can be used in
             different situations
@@ -30,6 +33,9 @@ export default {
           <Description>- loading state for `Button` component</Description>
           <Description>- loading page</Description>
 
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { DotLoading } from @smart-design/components`} />
+          <Description>###Example</Description>
           <Primary />
           <ArgsTable story={PRIMARY_STORY} />
         </>

--- a/src/components/dot-loading/dot-loading.styles.tsx
+++ b/src/components/dot-loading/dot-loading.styles.tsx
@@ -107,7 +107,7 @@ const LoaderDot = styled.div<DotLoadingTransientProps>`
   ${({ $size }) => dotSizes[$size]}
   border-radius: 50%;
   background: ${({ theme, $disabled }) =>
-    $disabled ? theme.dotLoading.disabledColor : theme.color.neutral};
+    $disabled ? theme.common.disabledSurfaceColor : theme.color.neutral};
   animation-timing-function: cubic-bezier(0, 1, 1, 0);
 `;
 

--- a/src/components/form-field/form-field.stories.tsx
+++ b/src/components/form-field/form-field.stories.tsx
@@ -9,6 +9,7 @@ import {
   ArgsTable,
   Stories,
   PRIMARY_STORY,
+  Source,
 } from "@storybook/addon-docs";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
@@ -26,7 +27,12 @@ export default {
         <>
           <Title>FormField</Title>
           <Subtitle>FormField component for SC projects</Subtitle>
+          <Description>##Overview</Description>
           <Description>`FormField` component is used as **Input** field for forms</Description>
+
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { FormField } from @smart-design/components`} />
+          <Description>###Example</Description>
           <Primary />
           <ArgsTable story={PRIMARY_STORY} />
           <Stories title='References' />

--- a/src/components/form-field/form-field.styles.tsx
+++ b/src/components/form-field/form-field.styles.tsx
@@ -25,7 +25,6 @@ import {
   spaceXL,
   mediaConfined,
   mediaWide,
-  red,
 } from "@tokens";
 
 type TextareaTransientProps = {
@@ -70,6 +69,7 @@ type IconTransientProps = {
   $hasFocus: boolean;
   $isDisabled?: boolean;
   $isFilled: boolean;
+  $error?: boolean;
 };
 
 export const variants = {
@@ -157,6 +157,7 @@ const baseLabel = (multiline?: boolean) => css`
   transform: translateY(-50%);
 
   cursor: text;
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
 
   transition-property: top, left, padding, color, font-size;
   transition-timing-function: ${motionEasingEnter};
@@ -188,16 +189,10 @@ const baseLabel = (multiline?: boolean) => css`
   }
 `;
 
-const stateLabel = {
-  enabled: css`
-    color: ${({ theme }) => theme.formField.label.textColor};
-  `,
-  disabled: css`
-    color: ${({ theme }) => theme.formField.label.disabledTextColor};
-
-    cursor: not-allowed;
-  `,
-};
+const disabledLabel = css`
+  color: ${({ theme }) => theme.common.disabledSurfaceColor};
+  pointer-events: none;
+`;
 
 const labelHasIcon = {
   small: css`
@@ -212,28 +207,61 @@ const labelHasIcon = {
     left: calc(${scale070} + ${scale110});
   `,
 };
-const filledLabel = ($error?: boolean) => css`
-  font-size: ${scale060};
-  top: calc(${borderWidth} / 2);
-  left: calc(${scale070} + ${borderWidth});
-  padding: 0 10px;
+const filledLabel = css`
+  font-size: ${scale060} !important;
+  top: calc(${borderWidth} / 2) !important;
+  left: calc(${scale070} + ${borderWidth}) !important;
+  padding: 0 ${spaceM};
 
   background-color: ${({ theme }) => theme.backgroundScreen};
-  color: ${({ theme }) =>
-    $error ? theme.formField.errorColor : theme.formField.filledBorderColor} !important;
-
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
   transition-delay: 0ms;
 
   &::after,
   &::before {
-    background-color: ${({ theme }) =>
-      $error ? theme.formField.errorColor : theme.formField.filledBorderColor};
+    background-color: ${({ theme }) => theme.common.overBackgroundNeutral};
 
     transform: scaleY(1) translateY(-50%);
     transition-duration: ${motionTimeM};
-
     transition-delay: ${motionTimeM};
   }
+`;
+const errorLabel = css`
+  color: ${({ theme }) => theme.common.errorColor};
+
+  &::before,
+  &::after {
+    background-color: ${({ theme }) => theme.common.errorColor};
+  }
+`;
+
+const Label = styled.label<LabelTransientProps>`
+  ${({ $multiline }) => baseLabel($multiline)}
+
+  ${({ $size }) => $size && sizes[$size].label}
+  ${({ $isIconSet, $size }) => $isIconSet && labelHasIcon[$size]}
+  ${({ $hasFocus, $isFilled }) => ($hasFocus || $isFilled) && filledLabel}
+  ${({ $isDisabled }) => $isDisabled && disabledLabel}
+  ${({ $error }) => $error && errorLabel}
+
+
+  ${({ $sizeConfined, $isIconSet }) =>
+    $sizeConfined &&
+    css`
+      @media ${mediaConfined} {
+        ${sizes[$sizeConfined].label}
+        ${$isIconSet && labelHasIcon[$sizeConfined]}
+      }
+    `};
+
+  ${({ $sizeWide, $isIconSet }) =>
+    $sizeWide &&
+    css`
+      @media ${mediaWide} {
+        ${sizes[$sizeWide].label}
+        ${$isIconSet && labelHasIcon[$sizeWide]}
+      }
+    `};
 `;
 
 /* Input styles */
@@ -242,60 +270,56 @@ const baseInput = css`
   border: none;
   outline: none;
   border-radius: ${borderRadiusS};
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
 
   color: ${({ theme }) => theme.color.neutral};
-`;
+  background-color: ${({ theme }) => theme.common.backgroundColor};
 
-const stateInput = {
-  enabled: css`
-    background-color: ${({ theme }) => theme.formField.input.backgroundColor};
-    &:hover {
-      background-color: ${({ theme }) => theme.formField.input.hoverBackgroundColor};
-    }
-  `,
-  disabled: css`
-    background-color: ${({ theme }) => theme.formField.input.disabledBackgroundColor};
-    cursor: not-allowed;
-  `,
-};
+  border-width: ${borderWidth};
+  border-style: solid;
+  border-color: transparent;
 
-const filledInput = ($error?: boolean) => css`
-  border: ${borderWidth} solid ${({ theme }) => ($error ? red : theme.formField.filledBorderColor)} !important;
-  background-color: ${({ theme }) => theme.backgroundScreen} !important;
-  transition-delay: 0ms;
+  border-bottom-width: calc(${borderWidth} * 2);
+  border-bottom-color: ${({ theme }) => theme.common.overBackgroundNeutral};
 
   &:hover {
-    background-color: inherit;
+    border-bottom-color: ${({ theme }) => theme.color.neutral} !important;
   }
 `;
 
-/** Icon styles */
-const baseIcon = (filled?: boolean) => css`
-  color: ${({ theme }) => (filled ? theme.color.neutral : theme.formField.label.textColor)};
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  z-index: 2;
-  top: 50%;
-  left: calc(${spaceM});
-  transform: translateY(-50%);
+const disabledInput = (isFilled?: boolean) => css`
+  background-color: ${({ theme }) => theme.common.disabledBackgroundColor};
+  border-color: ${({ theme }) => isFilled && theme.common.disabledSurfaceColor} !important;
+  border-bottom-color: ${({ theme }) => theme.common.disabledSurfaceColor};
+  pointer-events: none;
 `;
 
-const FormFieldContainer = styled.div`
-  position: relative;
-  width: 400px;
+const filledInput = css`
+  color: ${({ theme }) => theme.color.neutral};
+  border-top-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  border-left-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  border-right-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  background-color: ${({ theme }) => theme.backgroundScreen};
+
+  transition-delay: 0ms;
+`;
+
+const errorInput = css`
+  border-color: ${({ theme }) => theme.common.errorColor};
+  border-bottom-color: ${({ theme }) => theme.common.errorColor};
 `;
 
 const Input = styled.input<InputTransientProps>`
   ${baseInput}
+
   ${({ $size }) => $size && sizes[$size].input}
   ${({ $size, $isIconSet }) => $isIconSet && inputHasIcon[$size]}
   ${({ $size, $variant }) => $variant && variants[$variant][$size]}
 
-  ${({ $isFilled, $hasFocus, $error }) => ($isFilled || $hasFocus) && filledInput($error)}
-  ${({ $isDisabled }) => ($isDisabled ? stateInput.disabled : stateInput.enabled)}
+  ${({ $isFilled, $hasFocus }) => ($isFilled || $hasFocus) && filledInput}
+  ${({ $isDisabled, $isFilled }) => $isDisabled && disabledInput($isFilled)}
+  ${({ $error }) => $error && errorInput}
 
   ${({ $sizeConfined, $isIconSet, $variant }) =>
     $sizeConfined &&
@@ -324,11 +348,12 @@ const Textarea = styled.textarea<TextareaTransientProps>`
   min-height: ${scale230};
   padding-top: ${spaceM};
   line-height: 1.25;
+  resize: vertical;
 
   ${({ $size }) => $size && sizes[$size].input}
-  ${({ $isFilled, $hasFocus, $error }) => ($isFilled || $hasFocus) && filledInput($error)}
-  ${({ $isDisabled }) => ($isDisabled ? stateInput.disabled : stateInput.enabled)}
-
+  ${({ $isFilled, $hasFocus }) => ($isFilled || $hasFocus) && filledInput}
+  ${({ $isDisabled, $isFilled }) => $isDisabled && disabledInput($isFilled)}
+  ${({ $error }) => $error && errorInput}
 
     ${({ $sizeConfined }) =>
     $sizeConfined &&
@@ -351,40 +376,41 @@ const TextareaWrapper = styled.div`
   padding: 20px 0;
 `;
 
-const Label = styled.label<LabelTransientProps>`
-  ${({ $multiline }) => baseLabel($multiline)}
+/** Icon styles */
+const baseIcon = css`
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
 
-  ${({ $size }) => $size && sizes[$size].label}
-  ${({ $isIconSet, $size }) => $isIconSet && labelHasIcon[$size]}
-  ${({ $hasFocus, $isFilled, $error }) => ($hasFocus || $isFilled) && filledLabel($error)}
-  ${({ $isDisabled }) => ($isDisabled ? stateLabel.disabled : stateLabel.enabled)}
-
-
-  ${({ $sizeConfined, $isIconSet }) =>
-    $sizeConfined &&
-    css`
-      @media ${mediaConfined} {
-        ${$sizeConfined && sizes[$sizeConfined].label}
-        ${$isIconSet && labelHasIcon[$sizeConfined]}
-      }
-    `};
-
-  ${({ $sizeWide, $isIconSet }) =>
-    $sizeWide &&
-    css`
-      @media ${mediaWide} {
-        ${$sizeWide && sizes[$sizeWide].label}
-        ${$isIconSet && labelHasIcon[$sizeWide]}
-      }
-    `};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  left: calc(${spaceM});
+  transform: translateY(-50%);
 `;
 
+const disabledIcon = css`
+  color: ${({ theme }) => theme.common.disabledSurfaceColor};
+`;
+
+const errorIcon = css`
+  color: ${({ theme }) => theme.common.errorColor};
+`;
 const IconWrapper = styled.div<IconTransientProps>`
-  ${({ $hasFocus, $isFilled }) => baseIcon($hasFocus || $isFilled)}
+  ${baseIcon}
+
+  ${({ $isDisabled }) => $isDisabled && disabledIcon}
+  ${({ $error }) => $error && errorIcon}
 `;
 
-const PasswordWrapper = styled.div<{ filled?: boolean }>`
-  color: ${({ theme, filled }) => (filled ? theme.color.neutral : theme.formField.label.textColor)};
+const FormFieldContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const PasswordWrapper = styled.button`
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
 
   display: flex;
   align-items: center;
@@ -396,6 +422,11 @@ const PasswordWrapper = styled.div<{ filled?: boolean }>`
   transform: translateY(-50%);
 
   cursor: pointer;
+
+  &:focus {
+    color: ${({ theme }) => theme.color.neutral};
+    outline: none;
+  }
 `;
 
 const ErrorMessageWrapper = styled.div`
@@ -405,7 +436,7 @@ const ErrorMessageWrapper = styled.div`
 `;
 
 const ErrorCaption = styled(Caption)`
-  color: ${({ theme }) => theme.formField.errorColor};
+  color: ${({ theme }) => theme.common.errorColor};
 `;
 
 export const Styled = {

--- a/src/components/form-field/form-field.tsx
+++ b/src/components/form-field/form-field.tsx
@@ -38,6 +38,11 @@ export const FormField: React.FC<FormFieldProps> = ({
     onBlur && onBlur(e);
   };
 
+  const handlePasswordSwitch = () => {
+    document.getElementById(id)?.focus();
+    setShowPassword(!showPassword);
+  };
+
   const isFilled = typeof value === "number" ? value != 0 : value.length > 0;
   const iconSize = size === "small" ? 16 : 18;
   const passwordVariantType = showPassword ? "text" : "password";
@@ -46,7 +51,12 @@ export const FormField: React.FC<FormFieldProps> = ({
   return (
     <Styled.FormFieldContainer>
       {Icon && (
-        <Styled.IconWrapper $isDisabled={disabled} $isFilled={isFilled} $hasFocus={hasFocus}>
+        <Styled.IconWrapper
+          $isDisabled={disabled}
+          $isFilled={isFilled}
+          $hasFocus={hasFocus}
+          $error={error}
+        >
           <Icon size={iconSize} />
         </Styled.IconWrapper>
       )}
@@ -114,8 +124,7 @@ export const FormField: React.FC<FormFieldProps> = ({
       {variant === "password" && !multiline && (
         <Styled.PasswordWrapper
           data-testid='formfield-password-switch'
-          filled={isFilled || hasFocus}
-          onClick={() => setShowPassword(!showPassword)}
+          onClick={handlePasswordSwitch}
         >
           {showPassword ? <BiShow size={18} /> : <BiHide size={18} />}
         </Styled.PasswordWrapper>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export { Menu, MenuDivider, MenuItem } from "./menu";
 export { ClickOutside } from "./click-outside";
 export { Grid, Col, Row, ContainedGrid } from "./grid-layout";
 export { Container } from "./container";
+export { SingleSelect, MultipleSelect } from "./select";

--- a/src/components/menu/components/menu-divider/menu-divider.tsx
+++ b/src/components/menu/components/menu-divider/menu-divider.tsx
@@ -4,10 +4,10 @@ import styled from "styled-components";
 
 const Divider = styled.div`
   height: 1px;
-  background-color: ${({ theme }) => theme.menu.menuDivider.backgroundColor};
+  background-color: ${({ theme }) => theme.common.disabledSurfaceColor};
   margin: ${spaceS} ${spaceXL};
 `;
 
 export const MenuDivider: React.FC = () => {
-  return <Divider />;
+  return <Divider role='separator' />;
 };

--- a/src/components/menu/components/menu-item/menu-item.styles.tsx
+++ b/src/components/menu/components/menu-item/menu-item.styles.tsx
@@ -64,8 +64,8 @@ const stateLink = {
   disabled: css`
     pointer-events: none;
 
-    color: ${({ theme }) => theme.menu.menuItem.disabledTextColor};
-    background-color: ${({ theme }) => theme.menu.menuItem.disabledBackgroundColor};
+    color: ${({ theme }) => theme.common.disabledSurfaceColor};
+    background-color: ${({ theme }) => theme.common.disabledBackgroundColor};
 
     &:focus {
       outline: none;

--- a/src/components/menu/components/menu-item/menu-item.tsx
+++ b/src/components/menu/components/menu-item/menu-item.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { Styled } from "./menu-item.styles";
 import { MenuItemProps } from "./menu-item.types";
-import { Button } from "../../../button/button";
 
 export const MenuItem: React.FC<MenuItemProps> = ({ children, to, disabled }) => {
   const tabIndex = disabled ? { tabIndex: -1 } : {};
   return (
     <Styled.MenuItem>
-      <Styled.Link $disabled={disabled} to={to} {...tabIndex}>
+      <Styled.Link role='menuitem' $disabled={disabled} to={to} {...tabIndex}>
         {children}
       </Styled.Link>
     </Styled.MenuItem>

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -10,11 +10,13 @@ import {
   ArgsTable,
   Stories,
   PRIMARY_STORY,
+  Source,
+  DescriptionType,
+  Subheading,
 } from "@storybook/addon-docs";
 import { MenuItem } from "./components/menu-item/menu-item";
 import { MenuDivider } from "./components";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: "Component/Menu",
   component: MenuComponent,
@@ -24,7 +26,12 @@ export default {
         <>
           <Title>Menu</Title>
           <Subtitle>Navigate Menu component</Subtitle>
+          <Description>##Overview</Description>
           <Description>`Menu` component is used as a navigation popover component</Description>
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { Menu } from @smart-design/components`} />
+          <Description>###Example</Description>
+
           <Primary />
           <ArgsTable story={PRIMARY_STORY} />
           <Stories title='References' />
@@ -35,10 +42,13 @@ export default {
   argTypes: {},
 } as ComponentMeta<typeof MenuComponent>;
 
-const Template: ComponentStory<typeof MenuComponent> = (args) => <MenuComponent {...args} />;
+const Template: ComponentStory<typeof MenuComponent> = (args, context) => {
+  const { storyId } = context;
+  return <MenuComponent {...args} id={`story${storyId}_${args.id}`} />;
+};
 
 export const Menu = Template.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
+
 Menu.args = {
   children: (
     <>
@@ -56,4 +66,5 @@ Menu.args = {
     </>
   ),
   triggerText: "Menu popover",
+  id: "menu",
 };

--- a/src/components/menu/menu.styles.tsx
+++ b/src/components/menu/menu.styles.tsx
@@ -1,4 +1,4 @@
-import { borderRadiusS, dropShadowM, scale350, spaceM } from "@tokens";
+import { borderRadiusS, scale350, spaceM, spaceS } from "@tokens";
 import { motion } from "framer-motion";
 import styled from "styled-components";
 
@@ -12,15 +12,15 @@ const MenuContainer = styled(motion.ul)`
 
   position: absolute;
   left: 0;
-  top: calc(100% + ${spaceM});
+  top: calc(100% + ${spaceS});
   z-index: 2000;
 
   transform-origin: top left;
 
-  background-color: ${({ theme }) => theme.menu.backgroundColor};
+  background-color: ${({ theme }) => theme.backgroundScreen};
   border-radius: ${borderRadiusS};
-  box-shadow: ${dropShadowM};
-  border: 1px solid ${({ theme }) => theme.menu.borderColor};
+  box-shadow: ${({ theme }) => theme.shadow.shadowM};
+  border: 1px solid ${({ theme }) => theme.common.overBackgroundNeutral};
 
   overflow: hidden;
 `;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -8,16 +8,23 @@ import { AnimatePresence } from "framer-motion";
 import { useKeyPress } from "../../hooks/use-key-press/use-key-press";
 import { IoChevronDownOutline, IoChevronUpOutline } from "react-icons/io5";
 
-export const Menu: React.FC<MenuProps> = ({ children, triggerProps, triggerText }) => {
+export const Menu: React.FC<MenuProps> = ({
+  className,
+  id,
+  children,
+  triggerProps,
+  triggerText,
+}) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const id = useId();
   const activeElement = useActiveElement();
 
   const closeMenu = useCallback(() => {
     if (!isOpen) setIsOpen(false);
   }, []);
 
-  const toggleMenu = useCallback(() => setIsOpen(!isOpen), []);
+  const toggleMenu = useCallback(() => setIsOpen((prevIsOpen) => !prevIsOpen), []);
+  const triggerId = `${id}-trigger`;
+  const menuId = `${id}-menu`;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -31,8 +38,9 @@ export const Menu: React.FC<MenuProps> = ({ children, triggerProps, triggerText 
 
   return (
     <ClickOutside id={id} callback={closeMenu}>
-      <Styled.MenuWrapper>
+      <Styled.MenuWrapper className={className}>
         <Button
+          id={triggerId}
           icon={isOpen ? IoChevronUpOutline : IoChevronDownOutline}
           size='medium'
           iconSize={18}
@@ -40,12 +48,19 @@ export const Menu: React.FC<MenuProps> = ({ children, triggerProps, triggerText 
           variant='text'
           {...triggerProps}
           onClick={toggleMenu}
+          aria-controls={menuId}
+          aria-expanded={isOpen}
+          aria-haspopup='menu'
         >
           {triggerText}
         </Button>
         <AnimatePresence>
           {isOpen && (
             <Styled.MenuContainer
+              id={menuId}
+              role='menu'
+              aria-label={triggerId}
+              aria-hidden={!isOpen}
               initial={{ scale: 0.95, opacity: 0.85 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ duration: 0.24, ease: [0, 0, 0.2, 1] }}

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,5 +1,9 @@
 import { ButtonProps } from "../button/button.types";
 export type MenuProps = {
+  /** Add custom css to select */
+  className?: string;
+  /** Id for the Menu */
+  id: string;
   /** Content of the menu. */
   children: React.ReactNode;
   /** Trigger button component props */

--- a/src/components/select/components/index.ts
+++ b/src/components/select/components/index.ts
@@ -1,0 +1,2 @@
+export { SelectValue } from "./select-value/select-value";
+export { SelectItem } from "./select-item";

--- a/src/components/select/components/select-item/index.ts
+++ b/src/components/select/components/select-item/index.ts
@@ -1,0 +1,1 @@
+export { SelectItem } from "./select-item";

--- a/src/components/select/components/select-item/select-item.styles.tsx
+++ b/src/components/select/components/select-item/select-item.styles.tsx
@@ -1,0 +1,98 @@
+import styled, { css } from "styled-components";
+
+import {
+  scale070,
+  scale080,
+  scale100,
+  spaceM,
+  scale090,
+  primary,
+  borderRadiusXXS,
+  scale120,
+} from "@tokens";
+
+import { SelectItemSizes } from "./select-item.types";
+
+type SelectItemTransientProps = {
+  $size: SelectItemSizes;
+  $disabled?: boolean;
+  $selected?: boolean;
+  $semiSelected?: boolean;
+};
+
+type MultipleSelectCheckboxProps = {
+  $selected?: boolean;
+};
+
+export const sizes = {
+  small: css`
+    font-size: ${scale070};
+    padding: ${spaceM} ${scale090};
+  `,
+
+  medium: css`
+    font-size: ${scale080};
+    padding: ${spaceM} ${scale090};
+  `,
+
+  large: css`
+    font-size: ${scale100};
+    padding: ${spaceM} ${scale120};
+  `,
+};
+
+const baseSelectItem = css`
+  width: 100%;
+  cursor: pointer;
+  height: 100%;
+
+  display: flex;
+  align-items: center;
+  position: relative;
+  color: ${({ theme }) => theme.color.neutral};
+
+  &:hover,
+  &:focus {
+    background-color: ${({ theme }) => theme.select.selectItem.hoverBackgroundColor};
+    outline: none;
+  }
+`;
+
+const selected = css`
+  background-color: ${({ theme }) => theme.select.selectItem.selectedBackgroundColor};
+  &:hover,
+  &:focus {
+    background-color: ${({ theme }) => theme.select.selectItem.selectedHoverBackgroundColor};
+  }
+`;
+
+const SelectItem = styled.li<SelectItemTransientProps>`
+  ${baseSelectItem}
+  ${({ $size }) => $size && sizes[$size]}
+  ${({ $selected }) => $selected && selected}
+`;
+
+const multipleSelectCheckboxSelected = css`
+  border-color: ${primary};
+  color: ${({ theme }) => theme.color.neutral};
+  background-color: ${primary};
+`;
+
+const MultipleSelectCheckbox = styled.div<MultipleSelectCheckboxProps>`
+  width: ${scale080};
+  height: ${scale080};
+  border: 2px solid ${({ theme }) => theme.color.neutral};
+  border-radius: ${borderRadiusXXS};
+  margin-right: ${spaceM};
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ $selected }) => $selected && multipleSelectCheckboxSelected}
+`;
+
+export const Styled = {
+  SelectItem,
+  MultipleSelectCheckbox,
+};

--- a/src/components/select/components/select-item/select-item.tsx
+++ b/src/components/select/components/select-item/select-item.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Styled } from "./select-item.styles";
+import { SelectItemProps } from "./select-item.types";
+import { FaCheck, FaMinus } from "react-icons/fa";
+
+export const SelectItem: React.FC<SelectItemProps> = ({
+  children,
+  selected,
+  size = "medium",
+  sizeConfined,
+  sizeWide,
+  multiple,
+  semiSelected,
+  ...props
+}) => {
+  const selectedIcon = () => {
+    if (selected) return <FaCheck size={10} />;
+    if (semiSelected) return <FaMinus data-testid='semiselected' size={10} />;
+  };
+
+  const checked = selected ? true : semiSelected ? "mixed" : false;
+
+  return (
+    <Styled.SelectItem
+      $size={size}
+      $sizeConfined={sizeConfined}
+      $sizeWide={sizeWide}
+      $selected={selected}
+      tabIndex={0}
+      {...props}
+    >
+      {multiple && (
+        <>
+          <Styled.MultipleSelectCheckbox
+            $selected={selected || semiSelected}
+            role='checkbox'
+            aria-checked={checked}
+          >
+            {selectedIcon()}
+          </Styled.MultipleSelectCheckbox>
+        </>
+      )}
+      {children}
+    </Styled.SelectItem>
+  );
+};

--- a/src/components/select/components/select-item/select-item.types.ts
+++ b/src/components/select/components/select-item/select-item.types.ts
@@ -1,0 +1,22 @@
+import { sizes, Styled } from "./select-item.styles";
+
+export type SelectItemSizes = keyof typeof sizes;
+
+export type SelectItemProps = React.ComponentProps<typeof Styled.SelectItem> & {
+  /** Select item content */
+  children?: React.ReactNode;
+  /** Custom css classname */
+  className?: string;
+  /** Is multiple Select item */
+  multiple?: boolean;
+  /** Is Selected Item selected */
+  selected: boolean;
+  /** Is at least one item selected */
+  semiSelected?: boolean;
+  /** The size on mobile screens or larger */
+  size?: SelectItemSizes;
+  /** The size on tablet screens or larger */
+  sizeConfined?: SelectItemSizes;
+  /** The size on desktop screens or larger */
+  sizeWide?: SelectItemSizes;
+};

--- a/src/components/select/components/select-value/index.ts
+++ b/src/components/select/components/select-value/index.ts
@@ -1,0 +1,1 @@
+export { SelectValue } from "./select-value";

--- a/src/components/select/components/select-value/select-value.styles.tsx
+++ b/src/components/select/components/select-value/select-value.styles.tsx
@@ -1,0 +1,52 @@
+import styled, { css } from "styled-components";
+import { mediaConfined, mediaWide } from "@tokens";
+import { SelectSizes } from "../../select.types";
+import { sizes } from "../../select.styles";
+
+type SelectValueTransientProps = {
+  $size: SelectSizes;
+  $sizeConfined?: SelectSizes;
+  $sizeWide?: SelectSizes;
+};
+
+export const ValueContainer = styled.button<SelectValueTransientProps>`
+  width: 100%;
+
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+
+  ${({ $size }) => $size && sizes[$size].value}
+
+  ${({ $sizeConfined }) =>
+    $sizeConfined &&
+    css`
+      @media ${mediaConfined} {
+        ${$sizeConfined && sizes[$sizeConfined].value}
+      }
+    `};
+
+  ${({ $sizeWide }) =>
+    $sizeWide &&
+    css`
+      @media ${mediaWide} {
+        ${$sizeWide && sizes[$sizeWide].value}
+      }
+    `};
+`;
+
+export const Value = styled.span`
+  color: ${({ theme }) => theme.color.neutral};
+
+  height: auto;
+  margin: 0;
+  padding: 0;
+  display: inline;
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+`;

--- a/src/components/select/components/select-value/select-value.tsx
+++ b/src/components/select/components/select-value/select-value.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { ValueContainer, Value } from "./select-value.styles";
+import { SelectValueProps } from "./select-value.types";
+
+export const SelectValue: React.FC<SelectValueProps> = ({
+  children,
+  id,
+  disabled,
+  size,
+  sizeConfined,
+  sizeWide,
+  ...props
+}) => {
+  return (
+    <ValueContainer
+      $size={size}
+      $sizeConfined={sizeConfined}
+      $sizeWide={sizeWide}
+      id={id}
+      data-testid='select-value-container'
+      disabled={disabled}
+      {...props}
+    >
+      <Value>{children}</Value>
+    </ValueContainer>
+  );
+};

--- a/src/components/select/components/select-value/select-value.types.ts
+++ b/src/components/select/components/select-value/select-value.types.ts
@@ -1,0 +1,28 @@
+import { sizes } from "../../select.styles";
+import { ReactNode } from "react";
+
+import { ValueContainer } from "./select-value.styles";
+import { SelectSizes } from "../../select.types";
+
+export type SelectValueProps = React.ComponentProps<typeof ValueContainer> & {
+  /** Label value */
+  children?: ReactNode;
+  /** Add custom css to select */
+  className?: string;
+  /** Id for the Select */
+  id: string;
+  /** Is Select opened */
+  isOpen?: boolean;
+  /** Is select filled */
+  isFilled?: boolean;
+  /** Is label disabled */
+  disabled?: boolean;
+  /** Set error state */
+  error?: boolean;
+  /** The size on mobile screens or larger */
+  size?: SelectSizes;
+  /** The size on tablet screens or larger */
+  sizeConfined?: SelectSizes;
+  /** The size on desktop screens or larger */
+  sizeWide?: SelectSizes;
+};

--- a/src/components/select/helpers/get-focused-element-by-initial-char-index.test.js
+++ b/src/components/select/helpers/get-focused-element-by-initial-char-index.test.js
@@ -1,0 +1,37 @@
+import { getFocusedElementByInitialCharIndex } from "./get-focused-element-by-initial-char-index";
+
+const mockOptions = [
+  { value: "mentor", label: "Mentoring" },
+  { value: "teaching", label: "Teaching" },
+  { value: "multiple", label: "Multiple" },
+  { value: "tutor", label: "Tutoring" },
+  { value: "1to1", label: "1 to 1" },
+  { value: "mixed", label: "Mixed" },
+  { value: "1to3", label: "1 to 3" },
+];
+
+describe("Select Functionality - getNextFocusedElementIndex", () => {
+  it.each([
+    { char: "t", activeElementId: null, expectedFocusedIndex: -1 },
+    { char: "z", activeElementId: "mentor", expectedFocusedIndex: -1 },
+    { char: "t", activeElementId: "mentor", expectedFocusedIndex: 1 },
+    { char: "t", activeElementId: "teaching", expectedFocusedIndex: 3 },
+    { char: "t", activeElementId: "tutor", expectedFocusedIndex: 1 },
+    { char: "1", activeElementId: "mentor", expectedFocusedIndex: 4 },
+    { char: "1", activeElementId: "1to1", expectedFocusedIndex: 6 },
+    { char: "m", activeElementId: "mentor", expectedFocusedIndex: 2 },
+    { char: "m", activeElementId: "multiple", expectedFocusedIndex: 5 },
+    { char: "m", activeElementId: "mixed", expectedFocusedIndex: 0 },
+  ])(
+    "should return option index $expectedFocusedIndex with char '$char' and activeElementId $activeElementId ",
+    ({ char, activeElementId, expectedFocusedIndex }) => {
+      const nextFocusedElement = getFocusedElementByInitialCharIndex({
+        char,
+        activeElementId,
+        options: mockOptions,
+      });
+
+      expect(nextFocusedElement).toBe(expectedFocusedIndex);
+    }
+  );
+});

--- a/src/components/select/helpers/get-focused-element-by-initial-char-index.ts
+++ b/src/components/select/helpers/get-focused-element-by-initial-char-index.ts
@@ -1,0 +1,35 @@
+import { SelectOption } from "../select.types";
+
+type Props = {
+  char: string;
+  options: SelectOption[];
+  activeElementId?: string;
+};
+
+export const getFocusedElementByInitialCharIndex = ({
+  char,
+  options,
+  activeElementId = document.activeElement?.id,
+}: Props): number => {
+  if (!activeElementId) return -1;
+
+  const focusableOptions = options.filter(({ label }) => label.toLowerCase().startsWith(char));
+
+  if (!focusableOptions.length) return -1;
+
+  const optionsValues = options.map(({ value }) => value);
+  const focusableOptionsValues = focusableOptions.map(({ value }) => value);
+  const activeElementIndex = focusableOptionsValues.indexOf(activeElementId);
+
+  let nextFocusedElementIndex;
+  if (activeElementIndex === -1) {
+    nextFocusedElementIndex = optionsValues.indexOf(focusableOptions[0].value);
+  } else {
+    const index =
+      activeElementIndex + 1 <= focusableOptionsValues.length - 1 ? activeElementIndex + 1 : 0;
+    nextFocusedElementIndex = optionsValues.indexOf(focusableOptions[index].value);
+  }
+
+  return nextFocusedElementIndex;
+  document.getElementById(options[nextFocusedElementIndex].value)?.focus();
+};

--- a/src/components/select/helpers/get-next-focused-element-index.test.js
+++ b/src/components/select/helpers/get-next-focused-element-index.test.js
@@ -1,0 +1,31 @@
+import { focusNextElement, getNextFocusedElementIndex } from "./get-next-focused-element-index";
+
+const mockOptions = [
+  { value: "value0", label: "label0" },
+  { value: "value1", label: "label1" },
+  { value: "value2", label: "label2" },
+  { value: "value3", label: "label3" },
+];
+
+describe("Select Functionality - getNextFocusedElementIndex", () => {
+  it.each([
+    { direction: 1, activeElementId: null, expectedFocusedIndex: -1 },
+    { direction: 1, activeElementId: "value0", expectedFocusedIndex: 1 },
+    { direction: 1, activeElementId: "value1", expectedFocusedIndex: 2 },
+    { direction: 1, activeElementId: "value3", expectedFocusedIndex: 0 },
+    { direction: -1, activeElementId: "value3", expectedFocusedIndex: 2 },
+    { direction: -1, activeElementId: "value2", expectedFocusedIndex: 1 },
+    { direction: -1, activeElementId: "value0", expectedFocusedIndex: 3 },
+  ])(
+    "should return option index $expectedFocusedIndex with direction $direction and activeElementId $activeElementId ",
+    ({ direction, activeElementId, expectedFocusedIndex }) => {
+      const nextFocusedElement = getNextFocusedElementIndex({
+        direction,
+        activeElementId,
+        options: mockOptions,
+      });
+
+      expect(nextFocusedElement).toBe(expectedFocusedIndex);
+    }
+  );
+});

--- a/src/components/select/helpers/get-next-focused-element-index.ts
+++ b/src/components/select/helpers/get-next-focused-element-index.ts
@@ -1,0 +1,30 @@
+import { SelectOption } from "../select.types";
+
+type Props = {
+  direction: -1 | 1;
+  options: SelectOption[];
+  activeElementId?: string;
+};
+
+export const getNextFocusedElementIndex = ({
+  direction,
+  options,
+  activeElementId = document.activeElement?.id,
+}: Props): number => {
+  if (!activeElementId) return -1;
+
+  const optionsValues = options.map(({ value }) => value);
+  const activeElementIndex = optionsValues.indexOf(activeElementId);
+
+  let nextFocusedElementIndex;
+
+  if (direction === -1) {
+    nextFocusedElementIndex =
+      activeElementIndex - 1 >= 0 ? activeElementIndex - 1 : options.length - 1;
+  } else {
+    nextFocusedElementIndex =
+      activeElementIndex + 1 <= options.length - 1 ? activeElementIndex + 1 : 0;
+  }
+
+  return nextFocusedElementIndex;
+};

--- a/src/components/select/helpers/index.ts
+++ b/src/components/select/helpers/index.ts
@@ -1,0 +1,2 @@
+export { getNextFocusedElementIndex } from "./get-next-focused-element-index";
+export { getFocusedElementByInitialCharIndex } from "./get-focused-element-by-initial-char-index";

--- a/src/components/select/index.ts
+++ b/src/components/select/index.ts
@@ -1,0 +1,2 @@
+export { MultipleSelect } from "./multiple-select";
+export { SingleSelect } from "./single-select";

--- a/src/components/select/multiple-select/index.ts
+++ b/src/components/select/multiple-select/index.ts
@@ -1,0 +1,1 @@
+export { MultipleSelect } from "./multiple-select";

--- a/src/components/select/multiple-select/multiple-select.stories.tsx
+++ b/src/components/select/multiple-select/multiple-select.stories.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { MultipleSelect as MultipleSelectComponent } from "./multiple-select";
+
+import { useForm, Controller } from "react-hook-form";
+
+import {
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  ArgsTable,
+  Stories,
+  PRIMARY_STORY,
+  DescriptionType,
+  Source,
+} from "@storybook/addon-docs";
+import { Button } from "@components";
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: "Component/Multiple Select",
+  component: MultipleSelectComponent,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title>Multiple Select</Title>
+          <Subtitle>Multiple Select dropdown component</Subtitle>
+          <Description>##Overview</Description>
+          <Description>
+            This component is used to select **one or more** options in forms or quizes
+          </Description>
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { MultiSelect } from @smart-design/components`} />
+          <Description>###Example</Description>
+
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories title='References' />
+        </>
+      ),
+    },
+  },
+  argTypes: {},
+} as ComponentMeta<typeof MultipleSelectComponent>;
+
+const Template: ComponentStory<typeof MultipleSelectComponent> = (args, context) => {
+  const { control, handleSubmit } = useForm();
+
+  const { storyId } = context;
+
+  const options = [
+    { value: "mentor", label: "Mentoring" },
+    { value: "teaching", label: "Teaching" },
+    { value: "multiple", label: "Multiple" },
+    { value: "tutor", label: "Tutoring" },
+    { value: "1to1", label: "1 to 1" },
+    { value: "mixed", label: "Mixed" },
+    { value: "1to3", label: "1 to 3" },
+  ];
+
+  const onSubmit = (data: any) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        control={control}
+        name='single-select'
+        defaultValue={args.defaultValue}
+        render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
+          <MultipleSelectComponent
+            innerRef={ref}
+            {...field}
+            {...args}
+            id={`story${storyId}_${args.id}`}
+            options={options}
+            onChange={onChange}
+            error={Boolean(error)}
+            errorMessage={error?.message}
+          />
+        )}
+        rules={{ required: "This field is required" }}
+      ></Controller>
+      <Button type='submit' style={{ marginTop: "30px" }}>
+        Submit and check data
+      </Button>
+    </form>
+  );
+};
+
+export const MultipleSelect = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+MultipleSelect.args = {
+  label: "Multiple Select",
+  defaultValue: ["mentor", "teaching"],
+  id: "multiple-slect",
+};
+MultipleSelect.parameters = {
+  docs: {
+    source: {
+      code: `const { control } = useForm();
+
+const options = [
+    { value: "mentor", label: "Mentoring" },
+    { value: "teaching", label: "Teaching" },
+    { value: "multiple", label: "Multiple" },
+    { value: "tutor", label: "Tutoring" },
+    { value: "1to1", label: "1 to 1" },
+    { value: "mixed", label: "Mixed" },
+    { value: "1to3", label: "1 to 3" },
+];
+
+return (
+    <Controller
+      control={control}
+      name='test'
+      render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
+        <MultipleSelect
+          innerRef={ref}
+          options={options}
+          onChange={onChange}
+          error={Boolean(error)}
+          errorMessage={error?.message}
+          {...field}
+          {...args} /** Args of the Multiple Select */
+        />
+      )}
+      rules={{ required: "This field is required" }}
+    ></Controller>
+);`,
+    },
+  },
+};

--- a/src/components/select/multiple-select/multiple-select.test.js
+++ b/src/components/select/multiple-select/multiple-select.test.js
@@ -1,0 +1,327 @@
+import React from "react";
+
+import { screen, fireEvent, act } from "@testing-library/react";
+import { render } from "@test-utils";
+
+import { MultipleSelect } from "./multiple-select";
+
+const mockOptions = [
+  { value: "value1", label: "label1" },
+  { value: "value2", label: "label2" },
+  { value: "value3", label: "label3" },
+  { value: "value4", label: "label4" },
+];
+
+const mockErrorMessage = "This is an error message";
+const mockLabel = "Description";
+
+const renderMultiSelect = ({ error = false, onChange = jest.fn(), ...rest } = {}) => {
+  render(
+    <MultipleSelect
+      id='single-select'
+      options={mockOptions}
+      onChange={onChange}
+      error={error}
+      errorMessage={mockErrorMessage}
+      {...rest}
+    />
+  );
+};
+
+afterEach(jest.clearAllMocks);
+
+describe(`MultipleSelect`, () => {
+  it("should render expected closed content with label", () => {
+    renderMultiSelect({ label: mockLabel });
+
+    expect(screen.getByText(mockLabel)).toBeInTheDocument();
+    expect(screen.queryByText(mockOptions[0].label)).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("select-options-container")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-controls",
+      "single-select-options-container"
+    );
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-labelledby",
+      "single-select-label"
+    );
+  });
+
+  it("should render expected closed content without label", () => {
+    renderMultiSelect({ labelDescription: "this is a description" });
+
+    expect(screen.queryByText(mockLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(mockOptions[0].label)).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("select-options-container")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-controls",
+      "single-select-options-container"
+    );
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-label",
+      "this is a description"
+    );
+  });
+
+  it("should open select options container on arrow click", () => {
+    renderMultiSelect();
+    fireEvent.click(screen.getByTestId("open-select-icon"));
+
+    expect(screen.getByRole("option", { name: "label1" })).toBeInTheDocument();
+  });
+  it("should open select options container and focus options container", () => {
+    renderMultiSelect();
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    mockOptions.map(({ label }) => expect(screen.getByText(label)).toBeInTheDocument());
+
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("select-options-container")).toHaveAttribute("aria-hidden", "false");
+    expect(screen.getByRole("listbox")).toHaveAttribute("aria-multiselectable", "true");
+  });
+
+  it("should show default value (initial value)", async () => {
+    renderMultiSelect({ defaultValue: [mockOptions[1].value, mockOptions[2].value] });
+
+    expect(
+      screen.getByText(`${mockOptions[1].label}, ${mockOptions[2].label}`)
+    ).toBeInTheDocument();
+  });
+
+  it("should not show default value if it is not an option", () => {
+    const defaultValue = [
+      {
+        label: "randomLabel",
+        value: "randomValue",
+      },
+      { label: mockOptions[3].label, value: mockOptions[3].value },
+      { label: mockOptions[2].label, value: mockOptions[2].value },
+    ];
+    renderMultiSelect({
+      defaultValue: [defaultValue[0].value, defaultValue[1].value, defaultValue[2].value],
+    });
+
+    expect(screen.queryByText(defaultValue[0].label)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(`${defaultValue[2].label}, ${defaultValue[1].label}`)
+    ).toBeInTheDocument();
+  });
+
+  it("should focus correct element when deselectiong option when open", () => {
+    const mockDefaultValue = [mockOptions[0].value];
+    renderMultiSelect({ value: mockDefaultValue, defaultValue: mockDefaultValue });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+    fireEvent.click(screen.getByTestId("remove-selection"));
+
+    expect(screen.getByRole("listbox")).toHaveFocus();
+  });
+
+  it("should focus correct element when deselectiong option when closed", () => {
+    const mockDefaultValue = [mockOptions[0].value];
+    renderMultiSelect({ value: mockDefaultValue, defaultValue: mockDefaultValue });
+
+    fireEvent.click(screen.getByTestId("remove-selection"));
+
+    expect(screen.getByTestId("select-value-container")).toHaveFocus();
+  });
+
+  it("should select and deselect option", async () => {
+    const firstSelectedIndex = 2;
+    const secondSelectedIndex = 1;
+    const mockOnChange = jest.fn();
+
+    renderMultiSelect({ onChange: mockOnChange });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    expect(screen.getByRole("listbox")).toHaveFocus();
+
+    /** SELECT OPTION */
+    fireEvent.click(screen.getByText(mockOptions[firstSelectedIndex].label));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith([mockOptions[firstSelectedIndex].value]);
+
+    expect(
+      screen.getByRole("button", { name: mockOptions[firstSelectedIndex].label })
+    ).toBeInTheDocument();
+
+    /** SELECT OPTION  2*/
+    fireEvent.click(screen.getByText(mockOptions[secondSelectedIndex].label));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(2);
+    expect(mockOnChange).toHaveBeenCalledWith([
+      mockOptions[secondSelectedIndex].value,
+      mockOptions[firstSelectedIndex].value,
+    ]);
+
+    expect(
+      screen.getByRole("button", {
+        name: `${mockOptions[firstSelectedIndex].label}, ${mockOptions[secondSelectedIndex].label}`,
+      })
+    ).toBeInTheDocument();
+
+    /** DESELECT OPTION  1*/
+    fireEvent.click(screen.getByText(mockOptions[firstSelectedIndex].label));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(3);
+    expect(mockOnChange).toHaveBeenCalledWith([mockOptions[secondSelectedIndex].value]);
+
+    expect(
+      screen.getByRole("button", { name: mockOptions[secondSelectedIndex].label })
+    ).toBeInTheDocument();
+  });
+
+  it("should remove all selected options", () => {
+    const mockOnChange = jest.fn();
+    const defaultValue = [mockOptions[1].value, mockOptions[2].value];
+    renderMultiSelect({ onChange: mockOnChange, value: defaultValue, defaultValue });
+
+    fireEvent.click(screen.getByTestId("remove-selection"));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(2);
+    expect(mockOnChange).toHaveBeenCalledWith([]);
+
+    expect(
+      screen.queryByRole("button", { name: `${mockOptions[1].label}, ${mockOptions[2].label}` })
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show select all option and select all options", () => {
+    renderMultiSelect({ selectAllOption: true });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    fireEvent.click(screen.getByText("Select all"));
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    expect(
+      screen.getByRole("button", { name: mockOptions.map(({ label }) => label).join(", ") })
+    ).toBeInTheDocument();
+  });
+
+  it("should be semi selected (select all option)", () => {
+    const defaultValue = [mockOptions[1].value, mockOptions[2].value];
+    renderMultiSelect({ value: defaultValue, defaultValue, selectAllOption: true });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    expect(screen.getByTestId("semiselected")).toBeInTheDocument();
+  });
+
+  it("should not show remove-options option when no options selected", () => {
+    const defaultValue = [mockOptions[1].value];
+    renderMultiSelect({ value: defaultValue, defaultValue });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    expect(screen.getByTestId("remove-selection")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: mockOptions[1].label }));
+
+    expect(screen.queryByTestId("remove-selection")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    { key: "Enter", keyCode: 13 },
+    { key: "SpaceBar", keyCode: 32 },
+  ])("should select option on $key keydown", async ({ key, keyCode }) => {
+    const mockOnChange = jest.fn();
+    renderMultiSelect({ onChange: mockOnChange });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    fireEvent.keyDown(screen.getByText("label2"), {
+      key: key,
+      code: key,
+      keyCode: keyCode,
+      charCode: keyCode,
+    });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith(["value2"]);
+
+    fireEvent.keyDown(screen.getByText("label3"), {
+      key: key,
+      code: key,
+      keyCode: keyCode,
+      charCode: keyCode,
+    });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(2);
+    expect(mockOnChange).toHaveBeenCalledWith(["value2", "value3"]);
+
+    expect(screen.getByRole("button", { name: "label2, label3" })).toBeInTheDocument();
+  });
+
+  it.each([
+    { key: "ArrowRight", keyCode: 39, initialFocus: "label1", expectedFocusLabel: "label2" },
+    { key: "ArrowRight", keyCode: 39, initialFocus: "label4", expectedFocusLabel: "label1" },
+    { key: "ArrowDown", keyCode: 40, initialFocus: "label1", expectedFocusLabel: "label2" },
+    { key: "ArrowDown", keyCode: 40, initialFocus: "label4", expectedFocusLabel: "label1" },
+    { key: "ArrowLeft", keyCode: 37, initialFocus: "label1", expectedFocusLabel: "label4" },
+    { key: "ArrowLeft", keyCode: 37, initialFocus: "label3", expectedFocusLabel: "label2" },
+    { key: "ArrowUp", keyCode: 38, initialFocus: "label1", expectedFocusLabel: "label4" },
+    { key: "ArrowUp", keyCode: 38, initialFocus: "label3", expectedFocusLabel: "label2" },
+    { key: "l", keyCode: 76, initialFocus: "label1", expectedFocusLabel: "label2" },
+    { key: "l", keyCode: 76, initialFocus: "label4", expectedFocusLabel: "label1" },
+  ])(
+    "should focus $expectedFocusLabel if initial focus is $initialFocus on $key keydown",
+    ({ key, keyCode, initialFocus, expectedFocusLabel }) => {
+      renderMultiSelect();
+
+      fireEvent.click(screen.getByTestId("select-value-container"));
+
+      act(() => screen.getByText(initialFocus).focus());
+
+      fireEvent.keyDown(screen.getByText(initialFocus), {
+        key: key,
+        code: key,
+        keyCode: keyCode,
+        charCode: keyCode,
+      });
+
+      expect(screen.getByText(expectedFocusLabel)).toHaveFocus();
+    }
+  );
+  it.each([
+    { key: "ArrowRight", keyCode: 39, initialFocus: "Select all", expectedFocusLabel: "label1" },
+    { key: "ArrowDown", keyCode: 40, initialFocus: "label4", expectedFocusLabel: "Select all" },
+    { key: "ArrowLeft", keyCode: 37, initialFocus: "label1", expectedFocusLabel: "Select all" },
+    { key: "ArrowUp", keyCode: 38, initialFocus: "Select all", expectedFocusLabel: "label4" },
+    { key: "s", keyCode: 83, initialFocus: "label4", expectedFocusLabel: "Select all" },
+  ])(
+    "should focus $expectedFocusLabel if initial focus is $initialFocus on $key keydown when select all option available",
+    ({ key, keyCode, initialFocus, expectedFocusLabel }) => {
+      renderMultiSelect({ selectAllOption: true });
+
+      fireEvent.click(screen.getByTestId("select-value-container"));
+
+      act(() => screen.getByText(initialFocus).focus());
+
+      fireEvent.keyDown(screen.getByText(initialFocus), {
+        key: key,
+        code: key,
+        keyCode: keyCode,
+        charCode: keyCode,
+      });
+
+      expect(screen.getByText(expectedFocusLabel)).toHaveFocus();
+    }
+  );
+
+  it("should render error message", () => {
+    const errorMessage = "bad request";
+    renderMultiSelect({ error: true, errorMessage });
+
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+});

--- a/src/components/select/multiple-select/multiple-select.tsx
+++ b/src/components/select/multiple-select/multiple-select.tsx
@@ -1,0 +1,330 @@
+import React, { useCallback, useState, AriaAttributes } from "react";
+import { AnimatePresence } from "framer-motion";
+import { IoChevronDownOutline, IoChevronUpOutline, IoCloseSharp } from "react-icons/io5";
+
+import { ClickOutside } from "../../click-outside";
+
+import { SelectItem, SelectValue } from "../components";
+import { MultipleSelectProps, SelectOption } from "../select.types";
+import { Styled } from "../select.styles";
+import { useEffect } from "react";
+import { useActiveElement } from "@hooks";
+import { getNextFocusedElementIndex } from "../helpers/get-next-focused-element-index";
+import { getFocusedElementByInitialCharIndex } from "../helpers/get-focused-element-by-initial-char-index";
+
+export const MultipleSelect: React.FC<MultipleSelectProps> = ({
+  className,
+  options,
+  id,
+  disabled = false,
+  error = false,
+  errorMessage,
+  label,
+  labelDescription,
+  innerRef,
+  onChange,
+  size = "medium",
+  sizeConfined,
+  sizeWide,
+  defaultValue,
+  selectAllOption,
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedOptions, setSelectedOptions] = useState<number[]>();
+  const activeElement = useActiveElement();
+
+  const labelId = `${id}-label`;
+  const valueContainerId = `${id}-value-container`;
+  const optionsContainerId = `${id}-options-container`;
+
+  const isFilled: boolean = Boolean(selectedOptions?.length);
+
+  const closeSelect = () => setIsOpen(false);
+  const toggleSelect = () => setIsOpen(!isOpen);
+
+  /** Get Initial Select Option */
+  useEffect(() => {
+    if (!defaultValue) return;
+
+    let initialSelection = options.filter(({ value }) => defaultValue.includes(value));
+
+    if (!initialSelection.length) return;
+
+    const initialSelectionIndex = initialSelection.map(({ value }) =>
+      options.findIndex(({ value: optionsValue }) => value === optionsValue)
+    );
+
+    onChange(defaultValue);
+    setSelectedOptions(initialSelectionIndex);
+  }, []);
+
+  /** Focus select select options container on open */
+  useEffect(() => {
+    if (!isOpen) return;
+    document.getElementById(optionsContainerId)?.focus();
+  }, [isOpen]);
+
+  /** Close select if focused out */
+  useEffect(() => {
+    if (!isOpen) return;
+    const select: HTMLElement | null = document.getElementById(id);
+    if (!select?.contains(activeElement)) {
+      closeSelect();
+    }
+  }, [activeElement, id]);
+
+  const selectOption = (index: number) => {
+    let newSelectedOptions: number[] | undefined;
+
+    if (selectedOptions?.includes(index)) {
+      newSelectedOptions = selectedOptions
+        .filter((optionIndex) => optionIndex !== index)
+        .map((index) => index);
+    } else {
+      newSelectedOptions = [...(selectedOptions ?? []), index];
+    }
+
+    const newValue = [...newSelectedOptions]
+      .sort((a, b) => a - b)
+      .map((index) => options[index].value);
+
+    onChange(newValue);
+    setSelectedOptions(newSelectedOptions);
+  };
+
+  const selectAllOptions = () => {
+    const optionsIndex = Array.from(Array(options.length), (_, i) => i);
+    if (selectedOptions?.length !== optionsIndex.length) {
+      const values = optionsIndex.map((i) => options[i].value);
+      setSelectedOptions(optionsIndex);
+      onChange(values);
+    } else {
+      setSelectedOptions(undefined);
+      onChange([]);
+    }
+  };
+
+  const deselectOption = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      onChange([]);
+      setSelectedOptions(undefined);
+      e.stopPropagation();
+    },
+    [onChange, setSelectedOptions]
+  );
+
+  const handleOptionsContainerKeyDown = (
+    e: React.KeyboardEvent<HTMLUListElement | HTMLDivElement>
+  ) => {
+    const key = e.key;
+    let nextFocusedElementIndex: number = -1;
+
+    const focusableOptions: SelectOption[] = selectAllOption
+      ? [{ label: "Select all", value: `selectAll_${optionsContainerId}` }, ...options]
+      : options;
+
+    switch (true) {
+      case key === "Escape":
+        e.preventDefault();
+        closeSelect();
+        document.getElementById(valueContainerId)?.focus();
+        break;
+      case key === "ArrowUp":
+      case key === "ArrowLeft":
+        e.preventDefault();
+        nextFocusedElementIndex = getNextFocusedElementIndex({
+          direction: -1,
+          options: focusableOptions,
+        });
+
+        break;
+      case key === "ArrowDown":
+      case key === "ArrowRight":
+        e.preventDefault();
+        nextFocusedElementIndex = getNextFocusedElementIndex({
+          direction: 1,
+          options: focusableOptions,
+        });
+        break;
+
+      case /[a-zA-Z0-9]/.test(key):
+        nextFocusedElementIndex = getFocusedElementByInitialCharIndex({
+          char: key.toLowerCase(),
+          options: focusableOptions,
+        });
+        break;
+      default:
+        break;
+    }
+
+    document.getElementById(focusableOptions[nextFocusedElementIndex]?.value)?.focus();
+  };
+
+  const handleOptionKeyDown = (index: number, options?: { selectAll?: boolean }) => (e: any) => {
+    switch (e.key) {
+      case " ":
+      case "SpaceBar":
+      case "Enter":
+        e.preventDefault();
+        options?.selectAll ? selectAllOptions() : selectOption(index);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const removeSelectedOptions = (event: React.MouseEvent<HTMLButtonElement>) => {
+    deselectOption(event);
+    isOpen
+      ? document.getElementById(optionsContainerId)?.focus()
+      : document.getElementById(valueContainerId)?.focus();
+  };
+
+  const getSelectedOptionsLabels = () =>
+    selectedOptions?.map((index) => options[index].label).join(", ");
+
+  const selectValueContainerAria: AriaAttributes = {
+    ...(label ? { "aria-labelledby": labelId } : { "aria-label": labelDescription }),
+    "aria-expanded": isOpen,
+    "aria-haspopup": "listbox",
+    "aria-controls": optionsContainerId,
+    "aria-invalid": Boolean(error),
+  };
+
+  return (
+    <ClickOutside id={id} callback={closeSelect}>
+      <Styled.SelectContainer
+        $isOpen={isOpen}
+        $isFilled={isFilled}
+        $isDisabled={disabled}
+        $error={error}
+        data-xds='Select'
+        className={className}
+        ref={innerRef}
+        {...props}
+      >
+        {label && (
+          <Styled.Label
+            $error={error}
+            $isDisabled={disabled}
+            $size={size}
+            $sizeConfined={sizeConfined}
+            $sizeWide={sizeWide}
+            $isFilled={isFilled}
+            $isOpen={isOpen}
+            id={labelId}
+          >
+            {label}
+          </Styled.Label>
+        )}
+        <SelectValue
+          id={valueContainerId}
+          data-testid='select-value-container'
+          disabled={disabled}
+          size={size}
+          sizeConfined={sizeConfined}
+          sizeWide={sizeWide}
+          onClick={toggleSelect}
+          {...selectValueContainerAria}
+        >
+          {getSelectedOptionsLabels()}
+        </SelectValue>
+
+        <Styled.SelectIconsContainer>
+          {isFilled && (
+            <Styled.SelectIcon
+              onClick={removeSelectedOptions}
+              data-testid='remove-selection'
+              disabled={disabled}
+            >
+              <IoCloseSharp size={16} />
+            </Styled.SelectIcon>
+          )}
+          |
+          {
+            <Styled.SelectIcon
+              onClick={toggleSelect}
+              data-testid='open-select-icon'
+              disabled={disabled}
+              aria-expanded={isOpen}
+              aria-haspopup='listbox'
+              aria-controls={optionsContainerId}
+            >
+              {isOpen ? <IoChevronUpOutline size={16} /> : <IoChevronDownOutline size={16} />}
+            </Styled.SelectIcon>
+          }
+        </Styled.SelectIconsContainer>
+      </Styled.SelectContainer>
+
+      <Styled.RelativeContainer>
+        <Styled.OptionsContainer
+          $error={error}
+          $isOpen={isOpen}
+          aria-hidden={!isOpen}
+          data-testid='select-options-container'
+        >
+          <AnimatePresence>
+            {isOpen && (
+              <Styled.OptionsWrapper
+                $isOpen={isOpen}
+                id={optionsContainerId}
+                tabIndex={-1}
+                onKeyDown={handleOptionsContainerKeyDown}
+                initial={{ maxHeight: 0 }}
+                animate={{ maxHeight: 252 }}
+                transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+                role='listbox'
+                aria-multiselectable={true}
+              >
+                {selectAllOption && (
+                  <SelectItem
+                    id={`selectAll_${optionsContainerId}`}
+                    tabIndex={0}
+                    multiple
+                    selected={selectedOptions?.length === options.length}
+                    semiSelected={isFilled}
+                    onClick={() => selectAllOptions()}
+                    onKeyDown={handleOptionKeyDown(0, { selectAll: true })}
+                    role='option'
+                    aria-selected={selectedOptions?.length === options.length}
+                  >
+                    Select all
+                  </SelectItem>
+                )}
+                {options.map(({ value: optionValue, label: optionLabel }, index) => {
+                  const selected = selectedOptions?.includes(index) ?? false;
+
+                  return (
+                    <SelectItem
+                      key={optionValue}
+                      id={optionValue}
+                      tabIndex={0}
+                      selected={selected}
+                      onClick={() => selectOption(index)}
+                      onKeyDown={handleOptionKeyDown(index)}
+                      multiple
+                      role='option'
+                      aria-selected={selected}
+                      size={size}
+                      sizeConfined={sizeConfined}
+                      sizeWide={sizeWide}
+                    >
+                      {optionLabel}
+                    </SelectItem>
+                  );
+                })}
+              </Styled.OptionsWrapper>
+            )}
+          </AnimatePresence>
+        </Styled.OptionsContainer>
+      </Styled.RelativeContainer>
+
+      {error && errorMessage && (
+        <Styled.SelectErrorCaption noMargin>{errorMessage}</Styled.SelectErrorCaption>
+      )}
+    </ClickOutside>
+  );
+};
+
+MultipleSelect.displayName = "MultipleSelect";

--- a/src/components/select/select.styles.tsx
+++ b/src/components/select/select.styles.tsx
@@ -1,0 +1,375 @@
+import { motion } from "framer-motion";
+import styled, { css, keyframes } from "styled-components";
+import {
+  borderRadiusS,
+  motionEasingEnter,
+  motionTimeM,
+  scale060,
+  scale070,
+  scale080,
+  scale100,
+  scale150,
+  scale160,
+  scale170,
+  scale005,
+  spaceM,
+  mediaConfined,
+  mediaWide,
+  motionTimeL,
+  motionEasingStandard,
+  primary,
+} from "@tokens";
+import { SelectSizes } from "./select.types";
+import { Caption } from "../caption";
+
+type LabelTransientProps = {
+  $isDisabled?: boolean;
+  $error?: boolean;
+  $size: SelectSizes;
+  $sizeConfined?: SelectSizes;
+  $sizeWide?: SelectSizes;
+  $isFilled: boolean;
+  $isOpen: boolean;
+};
+
+type SelectContainerTransientProps = {
+  $isDisabled?: boolean;
+  $isFilled: boolean;
+  $isOpen: boolean;
+  $error?: boolean;
+};
+
+type SelectOptionsContainerTransientProps = {
+  $isOpen?: boolean;
+};
+
+type SelectOptionsWrapperTransientProps = {
+  $error?: boolean;
+  $isOpen?: boolean;
+};
+
+const borderWidth = scale005;
+
+export const sizes = {
+  small: {
+    value: css`
+      font-size: ${scale070};
+      height: ${scale150};
+      padding-left: ${scale070};
+    `,
+    label: css`
+      font-size: ${scale070};
+    `,
+  },
+  medium: {
+    value: css`
+      font-size: ${scale080};
+      height: ${scale160};
+      padding-left: ${scale070};
+    `,
+    label: css`
+      font-size: ${scale080};
+    `,
+  },
+  large: {
+    value: css`
+      font-size: ${scale100};
+      height: ${scale170};
+      padding-left: ${scale080};
+    `,
+    label: css`
+      font-size: ${scale080};
+    `,
+  },
+};
+
+/***********  LABEL  ***********/
+const baseLabel = css`
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  left: ${scale070};
+  transform: translateY(-50%);
+  cursor: pointer;
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
+
+  transition-property: top, left, padding, font-size;
+  transition-timing-function: ${motionEasingEnter};
+  transition-duration: ${motionTimeM};
+
+  &::after,
+  &::before {
+    content: "";
+    position: absolute;
+    width: ${borderWidth};
+    height: 80%;
+
+    transform-origin: top;
+
+    transform: scaleY(0) translateY(-50%);
+    transition-property: transform, top, left;
+    transition-timing-function: ${motionEasingEnter};
+    transition-duration: 0ms;
+    transition-delay: 0ms;
+  }
+
+  &::after {
+    right: 0px;
+    top: 50%;
+  }
+  &::before {
+    left: 0px;
+    top: 50%;
+  }
+`;
+
+const disabledLabel = css`
+  color: ${({ theme }) => theme.common.disabledSurfaceColor};
+  pointer-events: none;
+  &::before,
+  &::after {
+    background-color: ${({ theme }) => theme.common.disabledSurfaceColor};
+  }
+`;
+
+const openLabel = css`
+  color: ${primary} !important;
+
+  &::after,
+  &::before {
+    background-color: ${primary} !important;
+  }
+`;
+
+const errorLabel = css`
+  color: ${({ theme }) => theme.common.errorColor};
+
+  &::before,
+  &::after {
+    background-color: ${({ theme }) => theme.common.errorColor};
+  }
+`;
+
+const filledLabel = css`
+  font-size: ${scale060} !important;
+  top: calc(${borderWidth} / 2) !important;
+  left: calc(${scale070} + ${borderWidth}) !important;
+  padding: 0 ${spaceM};
+  background-color: ${({ theme }) => theme.backgroundScreen};
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  transition-delay: 0ms;
+
+  &::after,
+  &::before {
+    background-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+    transform: scaleY(1) translateY(-50%);
+    transition-duration: ${motionTimeM};
+    transition-delay: ${motionTimeM};
+  }
+`;
+
+const Label = styled.label<LabelTransientProps>`
+  ${baseLabel}
+  ${({ $size }) => $size && sizes[$size].label}
+  ${({ $isFilled, $isOpen }) => ($isFilled || $isOpen) && filledLabel}
+  ${({ $isDisabled }) => $isDisabled && disabledLabel}
+  ${({ $isOpen }) => $isOpen && openLabel}
+  ${({ $error }) => $error && errorLabel}
+
+
+  ${({ $sizeConfined }) =>
+    $sizeConfined &&
+    css`
+      @media ${mediaConfined} {
+        ${$sizeConfined && sizes[$sizeConfined].label}
+      }
+    `};
+
+  ${({ $sizeWide }) =>
+    $sizeWide &&
+    css`
+      @media ${mediaWide} {
+        ${$sizeWide && sizes[$sizeWide].label}
+      }
+    `};
+`;
+
+/***********  SELECT CONTAINER  ***********/
+const baseSelectContainer = css`
+  position: relative;
+  z-index: 101;
+  white-space: nowrap;
+  width: 100%;
+  max-width: 100%;
+  border: none;
+  outline: none;
+  border-top-left-radius: ${borderRadiusS};
+  border-top-right-radius: ${borderRadiusS};
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  background-color: ${({ theme }) => theme.common.backgroundColor};
+  color: transparent;
+
+  border-width: ${borderWidth};
+  border-style: solid;
+  border-color: transparent;
+
+  border-bottom-width: calc(${borderWidth} * 2);
+  border-bottom-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+
+  &:hover,
+  &:focus-within {
+    border-bottom-color: ${({ theme }) => theme.color.neutral} !important;
+  }
+`;
+
+const disabledSelectContainer = (isFilled: boolean) => css`
+  background-color: ${({ theme }) => theme.common.disabledBackgroundColor};
+  border-color: ${({ theme }) => isFilled && theme.common.disabledSurfaceColor} !important;
+  border-bottom-color: ${({ theme }) => theme.common.disabledSurfaceColor};
+  pointer-events: none;
+`;
+
+const openSelectContainer = css`
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
+  border-color: ${primary} !important;
+  border-bottom-color: ${({ theme }) => theme.common.backgroundColor} !important;
+  background-color: ${({ theme }) => theme.backgroundScreen};
+`;
+
+const filledSelectContainer = css`
+  color: ${({ theme }) => theme.color.neutral};
+  border-top-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  border-left-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  border-right-color: ${({ theme }) => theme.common.overBackgroundNeutral};
+  background-color: ${({ theme }) => theme.backgroundScreen};
+
+  transition-delay: 0ms;
+`;
+
+const errorSelectContainer = css`
+  border-color: ${({ theme }) => theme.common.errorColor};
+  border-bottom-color: ${({ theme }) => theme.common.errorColor};
+`;
+
+const SelectContainer = styled.div<SelectContainerTransientProps>`
+  ${baseSelectContainer}
+
+  ${({ $isOpen }) => $isOpen && openSelectContainer}
+  ${({ $isFilled }) => $isFilled && filledSelectContainer}
+  ${({ $isDisabled, $isFilled }) => $isDisabled && disabledSelectContainer($isFilled)}
+  ${({ $error }) => $error && errorSelectContainer}
+`;
+
+/***********  SELECT CONTAINER ICONS  ***********/
+const SelectIconsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
+`;
+
+const SelectIcon = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0 ${spaceM};
+
+  color: ${({ theme }) => theme.common.overBackgroundNeutral};
+
+  &:focus,
+  &:hover {
+    color: ${({ theme }) => theme.color.neutral};
+    outline: none;
+  }
+`;
+
+/***********  SELECT OPTIONS CONTAINER RELATIVE CONTAINER ***********/
+const RelativeContainer = styled.div`
+  position: relative;
+`;
+
+/***********  SELECT OPTIONS CONTAINER ***********/
+
+const openOptionsContainer = css`
+  transition-property: padding;
+  transition-duration: ${motionTimeM};
+  transition-timing-function: ${motionEasingStandard};
+
+  box-shadow: ${({ theme }) => theme.shadow.shadowM};
+  background-color: ${({ theme }) => theme.backgroundScreen};
+  border-bottom-left-radius: ${borderRadiusS};
+  border-bottom-right-radius: ${borderRadiusS};
+  border-width: ${borderWidth};
+  border-style: solid;
+  border-top: none;
+  border-color: ${primary};
+`;
+
+const OptionsContainer = styled.div<SelectOptionsWrapperTransientProps>`
+  overflow: hidden;
+  width: 100%;
+
+  position: absolute;
+  left: 0;
+  top: calc(100%);
+  z-index: 102;
+
+  border-color: ${({ $error, theme }) =>
+    $error ? theme.common.errorColor : theme.common.overBackgroundNeutral};
+
+  ${({ $isOpen }) => $isOpen && openOptionsContainer}
+`;
+
+/***********  SELECT OPTIONS WRAPPER ***********/
+const hideScroll = keyframes`
+ from, to { overflow:hidden; } 
+`;
+
+const baseOptionsWrapper = css`
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const openOptionsWrapper = css`
+  padding: ${spaceM} 0;
+
+  overflow-y: auto;
+  overflow-x: hidden;
+  animation-duration: ${motionTimeL};
+  animation-name: ${hideScroll};
+  animation-fill-mode: backwards;
+`;
+
+const OptionsWrapper = styled(motion.ul)<SelectOptionsContainerTransientProps>`
+  ${baseOptionsWrapper}
+  ${({ $isOpen }) => $isOpen && openOptionsWrapper}
+`;
+
+/***********  SELECT ERROR ***********/
+const SelectErrorCaption = styled(Caption)`
+  color: ${({ theme }) => theme.common.errorColor};
+`;
+
+export const Styled = {
+  Label,
+  SelectContainer,
+  SelectIconsContainer,
+  SelectIcon,
+  OptionsContainer,
+  RelativeContainer,
+  OptionsWrapper,
+  SelectErrorCaption,
+};

--- a/src/components/select/select.types.ts
+++ b/src/components/select/select.types.ts
@@ -1,0 +1,60 @@
+import { sizes, Styled } from "./select.styles";
+
+export type SelectSizes = keyof typeof sizes;
+export type SelectOption = { label: string; value: string };
+
+type BaseSelectProps = {
+  /** Add custom css to select */
+  className?: string;
+  /** Id for the Select */
+  id: string;
+  /** Select options */
+  options: SelectOption[];
+  /** Disable the input or textarea */
+  disabled?: boolean;
+  /** Set error state */
+  error?: boolean;
+  /** Set error message */
+  errorMessage?: string;
+  /** Ref object */
+  innerRef?: any;
+  /** The size on mobile screens or larger */
+  size?: SelectSizes;
+  /** The size on tablet screens or larger */
+  sizeConfined?: SelectSizes;
+  /** The size on desktop screens or larger */
+  sizeWide?: SelectSizes;
+};
+
+type LabelProps =
+  | {
+      /** The label attribute for the `Select` component.
+       * @description If `label` attribute is used, don't set ~~`labelDescription`~~ attribute. `label` will be used for **ARIA** attributes
+       */
+      label: string;
+      labelDescription?: never;
+    }
+  | {
+      label?: never;
+      /** The aria-label attribute to descrbe `Select` component.
+       * @description `labelDescription` attribute is used to cover all used **ARIA** attributes. Don't set ~~`label`~~ attribute.
+       */
+      labelDescription: string;
+    };
+
+export type MultipleSelectProps = BaseSelectProps &
+  LabelProps & {
+    /** Enable select all option */
+    selectAllOption?: boolean;
+    /** Default value for Select component */
+    defaultValue?: string[];
+    /** @callback */
+    onChange: (options: string[] | undefined) => void;
+  };
+
+export type SingleSelectProps = BaseSelectProps &
+  LabelProps & {
+    defaultValue?: string;
+    /** @callback */
+    onChange: (options: string | undefined) => void;
+  };

--- a/src/components/select/single-select/index.ts
+++ b/src/components/select/single-select/index.ts
@@ -1,0 +1,1 @@
+export { SingleSelect } from "./single-select";

--- a/src/components/select/single-select/single-select.stories.tsx
+++ b/src/components/select/single-select/single-select.stories.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { SingleSelect as SingleSelectComponent } from "./single-select";
+
+import { useForm, Controller } from "react-hook-form";
+
+import {
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  ArgsTable,
+  Stories,
+  PRIMARY_STORY,
+  Source,
+} from "@storybook/addon-docs";
+import { Button } from "@components";
+
+export default {
+  title: "Component/Single Select",
+  component: SingleSelectComponent,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title>Single Select</Title>
+          <Subtitle>Single Select dropdown component</Subtitle>
+          <Description>##Overview</Description>
+          <Description>
+            This component is used to select **one single** option in forms or quizes
+          </Description>
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { SingleSelect } from @smart-design/components`} />
+          <Description>###Example</Description>
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories title='References' />
+        </>
+      ),
+    },
+  },
+  argTypes: {},
+} as ComponentMeta<typeof SingleSelectComponent>;
+
+const Template: ComponentStory<typeof SingleSelectComponent> = (args, context) => {
+  const { control, handleSubmit } = useForm();
+  const { storyId } = context;
+
+  const options = [
+    { value: "mentor", label: "Mentoring" },
+    { value: "teaching", label: "Teaching" },
+    { value: "multiple", label: "Multiple" },
+    { value: "tutor", label: "Tutoring" },
+    { value: "1to1", label: "1 to 1" },
+    { value: "mixed", label: "Mixed" },
+    { value: "1to3", label: "1 to 3" },
+  ];
+
+  const onSubmit = (data: any) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        control={control}
+        name='single-select'
+        defaultValue={"value1"}
+        render={({ field: { ref, onChange, ...field }, fieldState: { error } }) => (
+          <SingleSelectComponent
+            innerRef={ref}
+            {...field}
+            {...args}
+            id={`story${storyId}_${args.id}`}
+            options={options}
+            onChange={onChange}
+            error={Boolean(error)}
+            errorMessage={error?.message}
+          />
+        )}
+        rules={{ required: "This field is required" }}
+      ></Controller>
+      <Button type='submit' style={{ marginTop: "30px" }}>
+        Submit and check console
+      </Button>
+    </form>
+  );
+};
+
+export const SingleSelect = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+SingleSelect.args = {
+  label: "Single Select",
+  defaultValue: "mentor",
+  id: "single-slect",
+};
+SingleSelect.parameters = {
+  docs: {
+    source: {
+      code: `const { control } = useForm();
+
+const options = [
+    { value: "mentor", label: "Mentoring" },
+    { value: "teaching", label: "Teaching" },
+    { value: "multiple", label: "Multiple" },
+    { value: "tutor", label: "Tutoring" },
+    { value: "1to1", label: "1 to 1" },
+    { value: "mixed", label: "Mixed" },
+    { value: "1to3", label: "1 to 3" },
+];
+
+return (
+    <Controller
+      control={control}
+      name='single-select'
+      render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
+        <SingleSelect
+          innerRef={ref}
+          options={options}
+          onChange={onChange}
+          error={Boolean(error)}
+          errorMessage={error?.message}
+          {...field}
+          {...args} /** Args of the Single Select */
+        />
+      )}
+      rules={{ required: "This field is required" }}
+    ></Controller>
+);`,
+    },
+  },
+};

--- a/src/components/select/single-select/single-select.test.js
+++ b/src/components/select/single-select/single-select.test.js
@@ -1,0 +1,220 @@
+import React from "react";
+
+import { screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { render } from "@test-utils";
+
+import { SingleSelect } from "./single-select";
+
+const mockOptions = [
+  { value: "value1", label: "label1" },
+  { value: "value2", label: "label2" },
+  { value: "value3", label: "label3" },
+  { value: "value4", label: "label4" },
+];
+
+const mockErrorMessage = "This is an error message";
+const mockLabel = "Description";
+
+const renderSingleSelect = ({ error = false, onChange = jest.fn(), ...rest } = {}) => {
+  render(
+    <SingleSelect
+      id='single-select'
+      options={mockOptions}
+      onChange={onChange}
+      error={error}
+      errorMessage={mockErrorMessage}
+      {...rest}
+    />
+  );
+};
+
+afterEach(jest.clearAllMocks);
+
+describe(`SingleSelect`, () => {
+  it("should render expected closed content with label", () => {
+    renderSingleSelect({ label: mockLabel });
+
+    expect(screen.getByText(mockLabel)).toBeInTheDocument();
+    expect(screen.queryByText(mockOptions[0].label)).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("select-options-container")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-controls",
+      "single-select-options-container"
+    );
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-labelledby",
+      "single-select-label"
+    );
+  });
+
+  it("should render expected closed content without label", () => {
+    renderSingleSelect({ labelDescription: "this is a description" });
+
+    expect(screen.queryByText(mockLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(mockOptions[0].label)).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("select-options-container")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-controls",
+      "single-select-options-container"
+    );
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute(
+      "aria-label",
+      "this is a description"
+    );
+  });
+
+  it("should open select options container on arrow click", () => {
+    renderSingleSelect();
+    fireEvent.click(screen.getByTestId("open-select-icon"));
+
+    expect(screen.getByRole("option", { name: "label1" })).toBeInTheDocument();
+  });
+
+  it("should open select options container and focus options container", () => {
+    renderSingleSelect();
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    mockOptions.map(({ label }) =>
+      expect(screen.getByRole("option", { name: label })).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("select-options-container")).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("should show default value (initial value)", async () => {
+    renderSingleSelect({ defaultValue: mockOptions[1].value });
+
+    expect(screen.getByRole("button", { name: mockOptions[1].label })).toBeInTheDocument();
+  });
+
+  it("should not show default value if it is not an option", () => {
+    const randomOption = {
+      label: "randomLabel",
+      value: "randomValue",
+    };
+    renderSingleSelect({ defaultValue: randomOption.value });
+
+    expect(screen.queryByText(randomOption.label)).not.toBeInTheDocument();
+  });
+
+  it("should focus correct element when deselecting option when open", () => {
+    const mockDefaultValue = mockOptions[0].value;
+    renderSingleSelect({ value: mockDefaultValue, defaultValue: mockDefaultValue });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+    fireEvent.click(screen.getByTestId("remove-selection"));
+
+    expect(screen.getByRole("listbox")).toHaveFocus();
+  });
+
+  it("should focus correct element when deselectiong option when closed", () => {
+    const mockDefaultValue = mockOptions[0].value;
+    renderSingleSelect({ value: mockDefaultValue, defaultValue: mockDefaultValue });
+
+    fireEvent.click(screen.getByTestId("remove-selection"));
+
+    expect(screen.getByTestId("select-value-container")).toHaveFocus();
+  });
+
+  it("should select and deselect option", async () => {
+    const selectedOptionIndex = 2;
+    const mockOnChange = jest.fn();
+
+    renderSingleSelect({ onChange: mockOnChange });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    expect(screen.getByRole("listbox")).toHaveFocus();
+
+    /** SELECT OPTION */
+    fireEvent.click(screen.getByRole("option", { name: mockOptions[selectedOptionIndex].label }));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith(mockOptions[selectedOptionIndex].value);
+
+    await waitFor(() => {
+      expect(screen.queryByText(mockOptions[3].label)).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("select-value-container")).toHaveFocus();
+
+    expect(screen.getByText(mockOptions[selectedOptionIndex].label)).toBeInTheDocument();
+
+    /** DESELECT OPTION */
+    fireEvent.click(screen.getByTestId("remove-selection"));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(2);
+    expect(mockOnChange).toHaveBeenCalledWith("");
+
+    expect(screen.queryByText(mockOptions[selectedOptionIndex].label)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    { key: "Enter", keyCode: 13 },
+    { key: "SpaceBar", keyCode: 32 },
+  ])("should select option on $key keydown", async ({ key, keyCode }) => {
+    const mockOnChange = jest.fn();
+    renderSingleSelect({ onChange: mockOnChange });
+
+    fireEvent.click(screen.getByTestId("select-value-container"));
+
+    fireEvent.keyDown(screen.getByText("label2"), {
+      key: key,
+      code: key,
+      keyCode: keyCode,
+      charCode: keyCode,
+    });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith("value2");
+
+    await waitFor(() => {
+      expect(screen.queryByText("label3")).not.toBeInTheDocument();
+    });
+  });
+
+  it.each([
+    { key: "ArrowRight", keyCode: 39, initialFocus: "label1", expectedFocusLabel: "label2" },
+    { key: "ArrowRight", keyCode: 39, initialFocus: "label4", expectedFocusLabel: "label1" },
+    { key: "ArrowDown", keyCode: 40, initialFocus: "label1", expectedFocusLabel: "label2" },
+    { key: "ArrowDown", keyCode: 40, initialFocus: "label4", expectedFocusLabel: "label1" },
+    { key: "ArrowLeft", keyCode: 37, initialFocus: "label1", expectedFocusLabel: "label4" },
+    { key: "ArrowLeft", keyCode: 37, initialFocus: "label3", expectedFocusLabel: "label2" },
+    { key: "ArrowUp", keyCode: 38, initialFocus: "label1", expectedFocusLabel: "label4" },
+    { key: "ArrowUp", keyCode: 38, initialFocus: "label3", expectedFocusLabel: "label2" },
+    { key: "l", keyCode: 76, initialFocus: "label1", expectedFocusLabel: "label2" },
+    { key: "l", keyCode: 76, initialFocus: "label4", expectedFocusLabel: "label1" },
+  ])(
+    "should focus $expectedFocusLabel if initial focus is $initialFocus on $key keydown",
+    ({ key, keyCode, initialFocus, expectedFocusLabel }) => {
+      renderSingleSelect();
+
+      fireEvent.click(screen.getByTestId("select-value-container"));
+
+      act(() => screen.getByText(initialFocus).focus());
+
+      fireEvent.keyDown(screen.getByText(initialFocus), {
+        key: key,
+        code: key,
+        keyCode: keyCode,
+        charCode: keyCode,
+      });
+
+      expect(screen.getByRole("option", { name: expectedFocusLabel })).toHaveFocus();
+    }
+  );
+
+  it("should render error message", () => {
+    const errorMessage = "bad request";
+    renderSingleSelect({ error: true, errorMessage });
+
+    expect(screen.getByTestId("select-value-container")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+});

--- a/src/components/select/single-select/single-select.tsx
+++ b/src/components/select/single-select/single-select.tsx
@@ -1,0 +1,267 @@
+import React, { useCallback, useState, AriaAttributes } from "react";
+import { AnimatePresence } from "framer-motion";
+import { IoChevronDownOutline, IoChevronUpOutline, IoCloseSharp } from "react-icons/io5";
+
+import { ClickOutside } from "../../click-outside";
+
+import { SelectItem, SelectValue } from "../components";
+import { SingleSelectProps } from "../select.types";
+import { Styled } from "../select.styles";
+import { useEffect } from "react";
+import { useActiveElement } from "@hooks";
+import { getNextFocusedElementIndex } from "../helpers/get-next-focused-element-index";
+import { getFocusedElementByInitialCharIndex } from "../helpers/get-focused-element-by-initial-char-index";
+
+export const SingleSelect: React.FC<SingleSelectProps> = ({
+  className,
+  options,
+  id,
+  disabled = false,
+  error = false,
+  errorMessage,
+  label,
+  labelDescription,
+  innerRef,
+  onChange,
+  size = "medium",
+  sizeConfined,
+  sizeWide,
+  defaultValue,
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<number>();
+  const activeElement = useActiveElement();
+
+  const labelId = `${id}-label`;
+  const valueContainerId = `${id}-value-container`;
+  const optionsContainerId = `${id}-options-container`;
+
+  const isFilled: boolean = Boolean(selectedOption || selectedOption === 0);
+
+  const closeSelect = () => setIsOpen(false);
+  const toggleSelect = () => setIsOpen(!isOpen);
+
+  /** Get Initial Select Option */
+  useEffect(() => {
+    if (!defaultValue) return;
+
+    const initialSelection = options.find(({ value }) => value === defaultValue);
+
+    if (!initialSelection) return;
+
+    onChange(initialSelection.value);
+    setSelectedOption(options.indexOf(initialSelection));
+  }, []);
+
+  /** Focus select select options container on open */
+  useEffect(() => {
+    if (!isOpen) return;
+    document.getElementById(optionsContainerId)?.focus();
+  }, [isOpen]);
+
+  /** Close select if focused out */
+  useEffect(() => {
+    if (!isOpen) return;
+    const select: HTMLElement | null = document.getElementById(id);
+    if (!select?.contains(activeElement)) {
+      closeSelect();
+    }
+  }, [activeElement, id]);
+
+  const selectOption = (index: number) => {
+    setSelectedOption(index);
+    onChange(options[index].value);
+    closeSelect();
+    document.getElementById(valueContainerId)?.focus();
+  };
+
+  const deselectOption = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      onChange("");
+      setSelectedOption(undefined);
+      e.stopPropagation();
+    },
+    [onChange, setSelectedOption]
+  );
+
+  const handleOptionsContainerKeyDown = (
+    e: React.KeyboardEvent<HTMLUListElement | HTMLDivElement>
+  ) => {
+    const key = e.key;
+    let nextFocusedElementIndex: number = -1;
+    switch (true) {
+      case key === "Escape":
+        e.preventDefault();
+        closeSelect();
+        document.getElementById(valueContainerId)?.focus();
+        break;
+      case key === "ArrowUp":
+      case key === "ArrowLeft":
+        e.preventDefault();
+        nextFocusedElementIndex = getNextFocusedElementIndex({ direction: -1, options });
+
+        break;
+      case key === "ArrowDown":
+      case key === "ArrowRight":
+        e.preventDefault();
+        nextFocusedElementIndex = getNextFocusedElementIndex({ direction: 1, options });
+        break;
+
+      case /[a-zA-Z0-9]/.test(key):
+        nextFocusedElementIndex = getFocusedElementByInitialCharIndex({
+          char: key.toLowerCase(),
+          options,
+        });
+        break;
+      default:
+        break;
+    }
+
+    document.getElementById(options[nextFocusedElementIndex]?.value)?.focus();
+  };
+
+  const handleOptionKeyDown = (index: number) => (e: any) => {
+    switch (e.key) {
+      case " ":
+      case "SpaceBar":
+      case "Enter":
+        e.preventDefault();
+        selectOption(index);
+        closeSelect();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const removeSelectedOptions = (event: React.MouseEvent<HTMLButtonElement>) => {
+    deselectOption(event);
+    isOpen
+      ? document.getElementById(optionsContainerId)?.focus()
+      : document.getElementById(valueContainerId)?.focus();
+  };
+
+  const selectValueContainerAria: AriaAttributes = {
+    ...(label ? { "aria-labelledby": labelId } : { "aria-label": labelDescription }),
+    "aria-expanded": isOpen,
+    "aria-haspopup": "listbox",
+    "aria-controls": optionsContainerId,
+    "aria-invalid": Boolean(error),
+  };
+
+  return (
+    <ClickOutside id={id} callback={closeSelect}>
+      <Styled.SelectContainer
+        $isOpen={isOpen}
+        $isFilled={isFilled}
+        $isDisabled={disabled}
+        $error={error}
+        data-xds='Select'
+        className={className}
+        ref={innerRef}
+        {...props}
+      >
+        {label && (
+          <Styled.Label
+            $error={error}
+            $isDisabled={disabled}
+            $size={size}
+            $sizeConfined={sizeConfined}
+            $sizeWide={sizeWide}
+            $isFilled={isFilled}
+            $isOpen={isOpen}
+            id={labelId}
+          >
+            {label}
+          </Styled.Label>
+        )}
+        <SelectValue
+          id={valueContainerId}
+          data-testid='select-value-container'
+          disabled={disabled}
+          size={size}
+          sizeConfined={sizeConfined}
+          sizeWide={sizeWide}
+          onClick={toggleSelect}
+          {...selectValueContainerAria}
+        >
+          {options[selectedOption ?? -1]?.label}
+        </SelectValue>
+
+        <Styled.SelectIconsContainer>
+          {isFilled && (
+            <Styled.SelectIcon
+              onClick={removeSelectedOptions}
+              data-testid='remove-selection'
+              disabled={disabled}
+            >
+              <IoCloseSharp size={16} />
+            </Styled.SelectIcon>
+          )}
+          |
+          {
+            <Styled.SelectIcon
+              onClick={toggleSelect}
+              data-testid='open-select-icon'
+              disabled={disabled}
+              aria-expanded={isOpen}
+              aria-haspopup='listbox'
+              aria-controls={optionsContainerId}
+            >
+              {isOpen ? <IoChevronUpOutline size={16} /> : <IoChevronDownOutline size={16} />}
+            </Styled.SelectIcon>
+          }
+        </Styled.SelectIconsContainer>
+      </Styled.SelectContainer>
+
+      <Styled.RelativeContainer>
+        <Styled.OptionsContainer
+          $error={error}
+          $isOpen={isOpen}
+          aria-hidden={!isOpen}
+          data-testid='select-options-container'
+        >
+          <AnimatePresence>
+            {isOpen && (
+              <Styled.OptionsWrapper
+                $isOpen={isOpen}
+                id={optionsContainerId}
+                tabIndex={-1}
+                onKeyDown={handleOptionsContainerKeyDown}
+                initial={{ maxHeight: 0 }}
+                animate={{ maxHeight: 252 }}
+                transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+                role='listbox'
+              >
+                {options.map(({ value: optionValue, label: optionLabel }, index) => {
+                  const selected = selectedOption === index;
+
+                  return (
+                    <SelectItem
+                      key={optionValue}
+                      id={optionValue}
+                      selected={selected}
+                      onClick={() => selectOption(index)}
+                      onKeyDown={handleOptionKeyDown(index)}
+                      role='option'
+                      aria-selected={selected}
+                    >
+                      {optionLabel}
+                    </SelectItem>
+                  );
+                })}
+              </Styled.OptionsWrapper>
+            )}
+          </AnimatePresence>
+        </Styled.OptionsContainer>
+      </Styled.RelativeContainer>
+
+      {error && errorMessage && (
+        <Styled.SelectErrorCaption noMargin>{errorMessage}</Styled.SelectErrorCaption>
+      )}
+    </ClickOutside>
+  );
+};
+
+SingleSelect.displayName = "SingleSelect";

--- a/src/global-styles/base-styles.tsx
+++ b/src/global-styles/base-styles.tsx
@@ -1,4 +1,4 @@
-import { scale080, scale100 } from "@tokens";
+import { borderRadiusXS, scale030, scale080, scale100 } from "@tokens";
 import { createGlobalStyle } from "styled-components";
 
 export const BaseStyles = createGlobalStyle`
@@ -9,6 +9,22 @@ export const BaseStyles = createGlobalStyle`
     box-sizing: border-box;
   }
   
+  &::-webkit-scrollbar {
+    width: ${scale030};
+  }
+  &::-webkit-scrollbar-track {
+    background:  ${({ theme }) => theme.common.backgroundColor};
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    border-radius: ${borderRadiusXS};
+    background:  ${({ theme }) => theme.common.disabledSurfaceColor};
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background:${({ theme }) => theme.common.overBackgroundNeutral};
+  }
+
   body {
     font-family: 'Montserrat', 'Trebuchet MS', Arial, 'Helvetica Neue', sans-serif;
     background: white;
@@ -31,6 +47,15 @@ export const BaseStyles = createGlobalStyle`
     text-decoration: none;
   }
   
+  button{
+    padding:0;
+    margin:0;
+    background: transparent;
+    outline: none;
+    border:none;
+    cursor: pointer;
+  }
+
   a:hover,
   a:focus {
   }

--- a/src/global-styles/theme/themes.ts
+++ b/src/global-styles/theme/themes.ts
@@ -4,15 +4,26 @@ import {
   gray200,
   gray300,
   gray400,
-  gray500,
   gray600,
   gray700,
   gray800,
   gray900,
   primary400,
   primary600,
-  red,
-  darkRed,
+  dropShadowS,
+  dropShadowM,
+  dropShadowL,
+  dropShadowXL,
+  dropShadowDarkS,
+  dropShadowDarkM,
+  dropShadowDarkL,
+  dropShadowDarkXL,
+  primary100,
+  primary200,
+  primary700,
+  primary800,
+  red400,
+  red500,
 } from "@tokens";
 
 import * as I from "./themes.types";
@@ -21,6 +32,9 @@ declare module "styled-components" {
   export interface DefaultTheme {
     color: I.ColorType;
     backgroundScreen: string;
+    common: I.Common;
+    shadow: I.Shadow;
+
     typography: {
       bodyTextColor: string;
       headlineTextColor: string;
@@ -30,22 +44,27 @@ declare module "styled-components" {
     button: {
       primary: I.PrimaryButtonTypes;
       secondary: I.SecondaryButtonTypes;
-      text: I.TextButtonTypes;
     };
-    dotLoading: {
-      disabledColor: string;
-    };
-    formField: {
-      filledBorderColor: string;
-      errorColor: string;
-      label: I.FormFieldLabelTyes;
-      input: I.FormFieldInputTypes;
-    };
+
     menu: I.Menu;
+    select: I.Select;
   }
 }
 
 export const lightTheme: DefaultTheme = {
+  common: {
+    disabledBackgroundColor: gray100,
+    backgroundColor: gray200,
+    disabledSurfaceColor: gray300,
+    overBackgroundNeutral: gray400,
+    errorColor: red500,
+  },
+  shadow: {
+    shadowS: dropShadowS,
+    shadowM: dropShadowM,
+    shadowL: dropShadowL,
+    shadowXL: dropShadowXL,
+  },
   color: {
     neutral: "black",
     invertedNeutral: "white",
@@ -57,54 +76,46 @@ export const lightTheme: DefaultTheme = {
     heroTextColor: "black",
     captionTextColor: gray700,
   },
-  dotLoading: {
-    disabledColor: gray400,
-  },
+
   button: {
     primary: {
       hoverBackgroundColor: primary600,
-      disabledTextColor: gray400,
-      disabledBackgroundColor: gray300,
     },
     secondary: {
       hoverBackgroundColor: gray200,
-      disabledTextColor: gray400,
-      disabledBorderColor: gray300,
-    },
-    text: {
-      disabledTextColor: gray400,
     },
   },
 
-  formField: {
-    filledBorderColor: gray500,
-    errorColor: red,
-    label: {
-      textColor: gray500,
-      disabledTextColor: gray800,
-    },
-    input: {
-      backgroundColor: gray200,
-      hoverBackgroundColor: gray300,
-      disabledBackgroundColor: gray500,
-    },
-  },
   menu: {
-    backgroundColor: "white",
-    borderColor: gray100,
-
     menuItem: {
-      hoverBackgroundColor: gray100,
-      disabledTextColor: gray400,
-      disabledBackgroundColor: gray300,
+      hoverBackgroundColor: gray200,
     },
-    menuDivider: {
-      backgroundColor: gray300,
+  },
+
+  select: {
+    selectItem: {
+      hoverBackgroundColor: gray200,
+      focusBackgroundColor: gray300,
+      selectedBackgroundColor: primary100,
+      selectedHoverBackgroundColor: primary200,
     },
   },
 };
 
 export const darkTheme: DefaultTheme = {
+  common: {
+    disabledBackgroundColor: gray800,
+    backgroundColor: gray700,
+    disabledSurfaceColor: gray600,
+    overBackgroundNeutral: gray400,
+    errorColor: red400,
+  },
+  shadow: {
+    shadowS: dropShadowDarkS,
+    shadowM: dropShadowDarkM,
+    shadowL: dropShadowDarkL,
+    shadowXL: dropShadowDarkXL,
+  },
   color: {
     neutral: "white",
     invertedNeutral: "black",
@@ -116,49 +127,27 @@ export const darkTheme: DefaultTheme = {
     heroTextColor: "white",
     captionTextColor: gray300,
   },
-  dotLoading: {
-    disabledColor: gray400,
-  },
+
   button: {
     primary: {
       hoverBackgroundColor: primary400,
-      disabledTextColor: gray400,
-      disabledBackgroundColor: gray600,
     },
     secondary: {
-      hoverBackgroundColor: gray600,
-      disabledTextColor: gray400,
-      disabledBorderColor: gray600,
-    },
-    text: {
-      disabledTextColor: gray400,
+      hoverBackgroundColor: gray800,
     },
   },
 
-  formField: {
-    filledBorderColor: gray300,
-    errorColor: darkRed,
-
-    label: {
-      textColor: gray300,
-      disabledTextColor: gray800,
-    },
-    input: {
-      backgroundColor: gray700,
-      hoverBackgroundColor: gray600,
-      disabledBackgroundColor: gray500,
-    },
-  },
   menu: {
-    backgroundColor: gray800,
-    borderColor: gray700,
     menuItem: {
       hoverBackgroundColor: gray700,
-      disabledTextColor: gray400,
-      disabledBackgroundColor: gray600,
     },
-    menuDivider: {
-      backgroundColor: gray600,
+  },
+  select: {
+    selectItem: {
+      hoverBackgroundColor: gray700,
+      focusBackgroundColor: gray600,
+      selectedBackgroundColor: primary800,
+      selectedHoverBackgroundColor: primary700,
     },
   },
 };

--- a/src/global-styles/theme/themes.types.ts
+++ b/src/global-styles/theme/themes.types.ts
@@ -1,45 +1,48 @@
+import { dropShadowS } from "../../tokens/shadow";
 export interface ColorType {
   neutral: string;
   invertedNeutral: string;
 }
 
+/** shadows */
+export interface Shadow {
+  shadowS: string;
+  shadowM: string;
+  shadowL: string;
+  shadowXL: string;
+}
+
+/** Common color effects */
+export interface Common {
+  disabledBackgroundColor: string;
+  disabledSurfaceColor: string;
+  overBackgroundNeutral: string;
+  backgroundColor: string;
+  errorColor: string;
+}
 export interface PrimaryButtonTypes {
   hoverBackgroundColor: string;
-  disabledTextColor: string;
-  disabledBackgroundColor: string;
 }
 export interface SecondaryButtonTypes {
   hoverBackgroundColor: string;
-  disabledBorderColor: string;
-  disabledTextColor: string;
-}
-
-export interface TextButtonTypes {
-  disabledTextColor: string;
-}
-
-export interface FormFieldLabelTyes {
-  textColor: string;
-  disabledTextColor: string;
-}
-export interface FormFieldInputTypes {
-  backgroundColor: string;
-  hoverBackgroundColor: string;
-  disabledBackgroundColor: string;
 }
 
 /** Menu item interface */
 type MenuItem = {
-  disabledTextColor: string;
-  disabledBackgroundColor: string;
   hoverBackgroundColor: string;
 };
-type MenuDivider = {
-  backgroundColor: string;
-};
+
 export interface Menu {
-  backgroundColor: string;
-  borderColor: string;
   menuItem: MenuItem;
-  menuDivider: MenuDivider;
+}
+
+/** Select interface */
+type SelectItem = {
+  hoverBackgroundColor: string;
+  focusBackgroundColor: string;
+  selectedBackgroundColor: string;
+  selectedHoverBackgroundColor: string;
+};
+export interface Select {
+  selectItem: SelectItem;
 }

--- a/src/tokens/color.ts
+++ b/src/tokens/color.ts
@@ -1,7 +1,7 @@
 //PRIMARY
 /** Primary color (HEX) token: **#FF5E0E** */ export const primary: string = "#FF5E0E";
-/** Primary color (HEX) token: **#FFDFCF** */ export const primary100: string = "#FFDFCF";
-/** Primary color (HEX) token: **#FFBF9F** */ export const primary200: string = "#FFBF9F";
+/** Primary color (HEX) token: **#FFEFE7** */ export const primary100: string = "#FFEFE7";
+/** Primary color (HEX) token: **#FFCFB7** */ export const primary200: string = "#FFCFB7";
 /** Primary color (HEX) token: **#FF9E6E** */ export const primary300: string = "#FF9E6E";
 /** Primary color (HEX) token: **#FF7E3E** */ export const primary400: string = "#FF7E3E";
 /** Primary color (HEX) token: **#FF5E0E** */ export const primary500: string = "#FF5E0E";
@@ -81,64 +81,65 @@ export const primary800_RGBA: string = "102, 38, 6";
 export const primary900_RGBA: string = "51, 19, 3";
 
 //GRAY
-/** Gray color (HEX) token: **#F7F7F7** */ export const gray100: string = "#F7F7F7";
-/** Gray color (HEX) token: **#E6E9EE** */ export const gray200: string = "#E6E9EE";
-/** Gray color (HEX) token: **#DDE0E4** */ export const gray300: string = "#DDE0E4";
-/** Gray color (HEX) token: **#818890** */ export const gray400: string = "#818890";
-/** Gray color (HEX) token: **#535661** */ export const gray500: string = "#535661";
-/** Gray color (HEX) token: **#4B4C53** */ export const gray600: string = "#4B4C53";
-/** Gray color (HEX) token: **#3A3D4A** */ export const gray700: string = "#3A3D4A";
+
+/** Gray color (HEX) token: **#FAFAFA** */ export const gray100: string = "#FAFAFA";
+/** Gray color (HEX) token: **#F2F3F4** */ export const gray200: string = "#F2F3F4";
+/** Gray color (HEX) token: **#D3D4DA** */ export const gray300: string = "#D3D4DA";
+/** Gray color (HEX) token: **#9EA1AE** */ export const gray400: string = "#9EA1AE";
+/** Gray color (HEX) token: **#7B7E8C** */ export const gray500: string = "#7B7E8C";
+/** Gray color (HEX) token: **#606370** */ export const gray600: string = "#606370";
+/** Gray color (HEX) token: **#444651** */ export const gray700: string = "#444651";
 /** Gray color (HEX) token: **#2E3039** */ export const gray800: string = "#2E3039";
 /** Gray color (HEX) token: **#1F2028** */ export const gray900: string = "#1F2028";
 
-/** Gray color (RGBA) token: **247, 247, 24**
+/** Gray color (RGBA) token: **250, 250, 250**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray100_RGBA: string = "247, 247, 24";
+export const gray100_RGBA: string = "250, 250, 250";
 
-/** Gray color (RGBA) token: **230, 233, 238**
+/** Gray color (RGBA) token: **242, 243, 244**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray200_RGBA: string = "230, 233, 238";
+export const gray200_RGBA: string = "242, 243, 244";
 
-/** Gray color (RGBA) token: **221, 224, 228**
+/** Gray color (RGBA) token: **211, 212, 218**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray300_RGBA: string = "221, 224, 228";
+export const gray300_RGBA: string = "211, 212, 218";
 
-/** Gray color (RGBA) token: **129, 136, 144**
+/** Gray color (RGBA) token: **158, 161, 174**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray400_RGBA: string = "129, 136, 144";
+export const gray400_RGBA: string = "158, 161, 174";
 
-/** Gray color (RGBA) token: **83, 86, 97**
+/** Gray color (RGBA) token: **123, 126, 140**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray500_RGBA: string = "83, 86, 97";
+export const gray500_RGBA: string = "123, 126, 140";
 
-/** Gray color (RGBA) token: **75, 76, 83**
+/** Gray color (RGBA) token: **96, 99, 112**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray600_RGBA: string = "75, 76, 83";
+export const gray600_RGBA: string = "96, 99, 112";
 
-/** Gray color (RGBA) token: **58, 61, 74**
+/** Gray color (RGBA) token: **68, 70, 81**
  * @description Value used to introduce RGBA values
  *
  * **Usage** --> rgba( *[ token ]* , *[ alpha chanel ]* )
  */
-export const gray700_RGBA: string = "58, 61, 74";
+export const gray700_RGBA: string = "68, 70, 81";
 
 /** Gray color (RGBA) token: **46, 48, 57**
  * @description Value used to introduce RGBA values
@@ -155,7 +156,15 @@ export const gray800_RGBA: string = "46, 48, 57";
 export const gray900_RGBA: string = "31, 32, 40";
 
 //EXTRA
-/** Red color (HEX) token: **#cc0000** */ export const red: string = "#cc0000";
-/** Dark Red color (HEX) token: **#ff4d4d** */ export const darkRed: string = "#ff4d4d";
+/** Red color (HEX) token: **#fee8ed** */ export const red100: string = "#fee8ed";
+/** Red color (HEX) token: **#fcb9ca** */ export const red200: string = "#fcb9ca";
+/** Red color (HEX) token: **#fa8ba6** */ export const red300: string = "#fa8ba6";
+/** Red color (HEX) token: **#f64571** */ export const red400: string = "#f64571";
+/** Red color (HEX) token: **#F4164D** */ export const red500: string = "#F4164D";
+/** Red color (HEX) token: **#c3123e** */ export const red600: string = "#c3123e";
+/** Red color (HEX) token: **#920d2e** */ export const red700: string = "#920d2e";
+/** Red color (HEX) token: **#62091f** */ export const red800: string = "#62091f";
+/** Red color (HEX) token: **#31040f** */ export const red900: string = "#31040f";
+
 /** Green color (HEX) token: **#68d94a** */ export const green: string = "#68d94a";
 /** Yellow color (HEX) token: **#ffd644** */ export const yellow: string = "#ffd644";

--- a/src/tokens/shadow.ts
+++ b/src/tokens/shadow.ts
@@ -1,4 +1,23 @@
 /** Shadow token: **0 2px 5px 1px rgba(33, 42, 54, 0.15)**   */
-export const dropShadowS: string = "0 2px 5px 1px rgba(33, 42, 54, 0.15)";
+export const dropShadowS: string =
+  "rgba(0, 0, 0, 0.1) 0px 4px 6px -1px, rgba(0, 0, 0, 0.06) 0px 2px 4px -1px";
 /** Shadow token: **0 4px 16px 3px rgba(33, 42, 54, 0.13)**   */
-export const dropShadowM: string = "0 4px 16px 3px rgba(33, 42, 54, 0.13)";
+export const dropShadowM: string =
+  "rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px";
+/** Shadow token: **0 4px 16px 3px rgba(33, 42, 54, 0.13)**   */
+export const dropShadowL: string =
+  "rgba(0, 0, 0, 0.1) 0px 20px 25px -5px, rgba(0, 0, 0, 0.04) 0px 10px 10px -5px";
+/** Shadow token: **0 4px 16px 3px rgba(33, 42, 54, 0.13)**   */
+export const dropShadowXL: string = "rgba(0, 0, 0, 0.25) 0px 25px 50px -12px;";
+
+/** Shadow token: **0 2px 5px 1px rgba(33, 42, 54, 0.15)**   */
+export const dropShadowDarkS: string =
+  "rgba(255, 255, 255, 0.1) 0px 4px 6px -1px, rgba(255, 255, 255, 0.06) 0px 2px 4px -1px";
+/** Shadow token: **0 4px 16px 3px rgba(33, 42, 54, 0.13)**   */
+export const dropShadowDarkM: string =
+  "rgba(255, 255, 255, 0.1) 0px 10px 15px -3px, rgba(255, 255, 255, 0.05) 0px 4px 6px -2px";
+/** Shadow token: **0 4px 16px 3px rgba(33, 42, 54, 0.13)**   */
+export const dropShadowDarkL: string =
+  "rgba(255, 255, 255, 0.1) 0px 20px 25px -5px, rgba(255, 255, 255, 0.04) 0px 10px 10px -5px";
+/** Shadow token: **0 4px 16px 3px rgba(33, 42, 54, 0.13)**   */
+export const dropShadowDarkXL: string = "rgba(255, 255, 255, 0.25) 0px 25px 50px -12px;";

--- a/templates/component/component.stories.tsx
+++ b/templates/component/component.stories.tsx
@@ -10,9 +10,9 @@ import {
   ArgsTable,
   Stories,
   PRIMARY_STORY,
+  Source,
 } from "@storybook/addon-docs";
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: "storyType/Component",
   component: Component,
@@ -22,7 +22,11 @@ export default {
         <>
           <Title>Component</Title>
           <Subtitle>Subtitle</Subtitle>
-          <Description>MDX description</Description>
+          <Description>##Overview</Description>
+          <Description>Description</Description>
+          <Description>##Usage</Description>
+          <Source language='tsx' code={`import { Component } from @smart-design/components`} />
+          <Description>###Example</Description>
           <Primary />
           <ArgsTable story={PRIMARY_STORY} />
           <Stories title='References' />


### PR DESCRIPTION
## Related Jira ticket 🎫
[SC-35](https://smartcookie.atlassian.net/browse/SC-35)


## Implementation details 🕵️
- Build `SingleSelect` and `MultipleSelect` components. 
- They are located in different documents. Making them in one single component had too many switches

## Additional Info ℹ️
- Add custom storybook theming
- Clean `theme.ts`. Remove duplicated color combinations
- Update components with new shared keys.
- Update `create-component` script as well as templates to create richer documentation. 
- Add custom story IDs to be able to see both light and dark themes and interact with the components at the same time.
- Modify `Button` text variant hover effect
- Add ARIA attributes to `Menu` component.

